### PR TITLE
Fixes Zendesk variations & allows for loader switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ GENESYS_KNOWLEDGE_BASE_ID=
 # Base url for relative image urls
 RELATIVE_IMAGE_BASE_URL=
 ```
+### Selecting the Loader
+In the index.ts file you can comment out either the ZendeskLoader & ZendeskAdaptor or the Genesys ones. Depending on the source solution you want to GET Knowledge from. There are comments on these lines.
 
 ### Installation
 

--- a/src/genesys/genesys-loader.ts
+++ b/src/genesys/genesys-loader.ts
@@ -25,7 +25,7 @@ export class GenesysLoader implements Loader {
   public async run(_input?: ExternalContent): Promise<ExternalContent> {
     validateNonNull(this.adapter, 'Missing source adapter');
 
-    logger.info('Fetching data...');
+    logger.info('Fetching data... GENESYS');
     const [categories, labels, articles] = await Promise.all([
       this.adapter!.getAllCategories(),
       this.adapter!.getAllLabels(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import logger from './utils/logger.js';
 import { ObsoleteArticleRemover } from './uploader/obsolete-article-remover.js';
 import { GenesysSourceAdapter } from './genesys/genesys-source-adapter.js';
 import { GenesysLoader } from './genesys/genesys-loader.js';
+import { ZendeskLoader } from './zendesk/zendesk-loader.js';  //Added for ZendeskLoader use
+import { ZendeskAdapter } from './zendesk/zendesk-adapter.js';  //Added for ZendeskAdaptor
 
 dotEnvConfig();
 
@@ -19,7 +21,8 @@ const config = _.mapKeys(
 
 logger.debug('Configuration: ' + JSON.stringify(config));
 
-const sourceAdapter = new GenesysSourceAdapter();
+//const sourceAdapter = new GenesysSourceAdapter(); //commented out to use ZendeskLoader
+const sourceAdapter = new ZendeskAdapter();
 const destinationAdapter = new GenesysDestinationAdapter();
 
 try {
@@ -28,7 +31,8 @@ try {
       sourceAdapter,
       destinationAdapter,
     })
-    .loaders(new GenesysLoader())
+    //.loaders(new GenesysLoader()) //commented out to use ZendeskLoader
+    .loaders(new ZendeskLoader())
     .processors(new ImageProcessor())
     .aggregator(new DiffAggregator())
     .uploaders(new DiffUploader(), new ObsoleteArticleRemover())

--- a/src/zendesk/zendesk-loader.ts
+++ b/src/zendesk/zendesk-loader.ts
@@ -7,6 +7,7 @@ import { AdapterPair } from '../adapter/adapter-pair.js';
 import { Adapter } from '../adapter/adapter.js';
 import { validateNonNull } from '../utils/validate-non-null.js';
 import logger from '../utils/logger.js';
+import { convertHtmlToBlocks } from 'knowledge-html-converter';
 
 /**
  * ZendeskLoader is a specific {@Link Loader} implementation for fetching data from Zendesk's API
@@ -25,7 +26,7 @@ export class ZendeskLoader implements Loader {
   public async run(_input?: ExternalContent): Promise<ExternalContent> {
     validateNonNull(this.adapter, 'Missing source adapter');
 
-    logger.info('Fetching data...');
+    logger.info('Fetching data... ZENDESK');
     const [categories, labels, articles] = await Promise.all([
       this.adapter!.getAllCategories(),
       this.adapter!.getAllLabels(),
@@ -37,6 +38,20 @@ export class ZendeskLoader implements Loader {
     logger.info('Categories loaded: ' + data.categories.length);
     logger.info('Labels loaded: ' + data.labels.length);
     logger.info('Documents loaded: ' + data.documents.length);
+
+    //Added to convert rawHTML to the body of object in variation
+    data.documents.forEach((document) => {
+      [
+        ...(document.published?.variations || []),
+        ...(document.draft?.variations || []),
+      ].forEach((variation) => {
+        const blocks = convertHtmlToBlocks(variation.rawHtml || '');
+        variation.body = {
+          blocks,
+        };
+        delete variation.rawHtml;
+      });
+    });
 
     return data;
   }


### PR DESCRIPTION
There were errors being thrown in the Zendesk loader due to the convertHtml missing making the variations arry null. I also updated the readme to allow for easier switching between either the genesys loader or Zendesk loader.