### PR TITLE
Fix issue with paging in the Salesforce API

### DIFF
--- a/src/salesforce/salesforce-api.ts
+++ b/src/salesforce/salesforce-api.ts
@@ -183,7 +183,7 @@ export class SalesforceApi {
     const json = (await response.json()) as SalesforceResponse;
     let list = json[property] as T[];
     if (json.nextPageUrl) {
-      const tail = await this.getPage<T>(json.nextPageUrl, property);
+      const tail = await this.get<T>(json.nextPageUrl, property);
       list = list.concat(tail);
     }
 


### PR DESCRIPTION
The value of nextPageUrl from the Salesforce API is a relative URL. getPage does not add the baseURL in front of it, but get does. With the default paging of 20 items per page, this gets a Salesforce instance with more than 20 articles to successfully load a second page.

An alternate solution is to move the URL formatting logic from get to getPage like is done for the servicenow-api.