### PR TITLE
Handle errors with default image loader

### DIFF
--- a/src/processor/image-processor.ts
+++ b/src/processor/image-processor.ts
@@ -190,7 +190,7 @@ export class ImageProcessor implements Processor {
       .digest('hex');
   }
 
-  private async downloadImage(url: string): Promise<Image> {
+  private async downloadImage(url: string): Promise<Image | null> {
     return fetchImage(url);
   }
 


### PR DESCRIPTION
If the adapter's getAttachment fails, downloadImage is used instead. If it fails, the connector errors out. Allowing it to return null, lets processImageBlock handle it