### PR TITLE
Support sourceId when creating Sync job

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knowledge-connector-app",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knowledge-connector-app",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "dotenv": "16.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-connector-app",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Knowledge Connector App",
   "module": "./dist/index.js",
   "main": "./dist/index.js",

--- a/src/genesys/genesys-destination-api.ts
+++ b/src/genesys/genesys-destination-api.ts
@@ -142,6 +142,8 @@ export class GenesysDestinationApi extends GenesysApi {
     const kbId = this.getKnowledgeBaseId();
     const body: SyncDataRequest = {
       uploadKey,
+      sourceId: this.config?.genesysSourceId,
+      readonlyContent: this.config?.genesysReadonlyContent === 'true',
     };
     return this.fetch<SyncDataResponse>(
       `/api/v2/knowledge/knowledgeBases/${kbId}/synchronize/jobs`,

--- a/src/model/sync-data-request.ts
+++ b/src/model/sync-data-request.ts
@@ -1,3 +1,5 @@
 export interface SyncDataRequest {
   uploadKey: string;
+  sourceId?: string;
+  readonlyContent?: boolean;
 }

--- a/src/model/sync-export-model.ts
+++ b/src/model/sync-export-model.ts
@@ -8,8 +8,6 @@ import { DocumentAlternative } from './document-alternative.js';
 
 export interface SyncModel {
   version: number;
-  sourceId?: string;
-  readonlyContent?: boolean;
   importAction: {
     knowledgeBase: {
       id: string;

--- a/src/salesforce/salesforce-api.spec.ts
+++ b/src/salesforce/salesforce-api.spec.ts
@@ -48,7 +48,7 @@ describe('SalesforceApi', () => {
       await api.fetchAllArticles();
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://base-url/services/data/v56.0/support/knowledgeArticles?channel=Pkb&categories={"something":"someone","otherGroup":"other category"}',
+        'https://base-url/services/data/v56.0/support/knowledgeArticles?channel=Pkb&categories={"something":"someone","otherGroup":"other_category"}',
         {
           headers: {
             Authorization: 'Bearer access-token',

--- a/src/uploader/diff-uploader.ts
+++ b/src/uploader/diff-uploader.ts
@@ -33,8 +33,6 @@ export class DiffUploader implements Uploader {
 
     const data: SyncModel = {
       version: 3,
-      sourceId: this.config?.genesysSourceId,
-      readonlyContent: this.config?.genesysReadonlyContent === 'true',
       importAction: {
         knowledgeBase: {
           id: this.config!.genesysKnowledgeBaseId!,


### PR DESCRIPTION
Sending source ID in the create sync job request's body