### PR TITLE
Control which entity types are needed to fetch from the 3rd party

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,19 @@ RELATIVE_IMAGE_BASE_URL=
 #### Execution timeout
 
 ```
-# Terminates the application after the set timeout in seconds has been reached. Optional
+# Terminates the application after the set timeout in seconds has been reached.
 KILL_AFTER_LONG_RUNNING_SECONDS=
+```
+
+#### Fetch certain entity types only
+
+```
+# Fetch articles from 3rd party. Values: 'true' or 'false'. Default 'true'. 
+FETCH_ARTICLES=
+# Fetch categories from 3rd party. Values: 'true' or 'false'. Default 'true'.
+FETCH_CATEGORIES=
+# Fetch labels from 3rd party. Values: 'true' or 'false'. Default 'true'.
+FETCH_LABELS=
 ```
 
 ### Installation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "knowledge-connector-app",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knowledge-connector-app",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "dotenv": "16.4.5",
-        "knowledge-html-converter": "0.3.3",
+        "knowledge-html-converter": "0.3.4",
         "lodash": "4.17.21",
-        "undici": "6.18.2",
+        "undici": "6.19.2",
         "winston": "3.13.0"
       },
       "devDependencies": {
@@ -20,18 +20,18 @@
         "@tsconfig/node18": "18.2.4",
         "@types/lodash": "4.17.5",
         "@types/node": "18.15.3",
-        "@typescript-eslint/eslint-plugin": "7.12.0",
-        "@typescript-eslint/parser": "7.12.0",
+        "@typescript-eslint/eslint-plugin": "7.14.1",
+        "@typescript-eslint/parser": "7.14.1",
         "eslint": "8.57.0",
         "eslint-config-prettier": "9.1.0",
         "jest": "29.7.0",
-        "prettier": "3.3.1",
+        "prettier": "3.3.2",
         "rimraf": "5.0.7",
-        "ts-jest": "29.1.4",
+        "ts-jest": "29.1.5",
         "ts-jest-resolver": "2.0.1",
         "ts-node": "10.9.2",
         "tslib": "2.6.3",
-        "typescript": "5.4.5"
+        "typescript": "5.5.2"
       },
       "engines": {
         "node": ">=18",
@@ -1551,16 +1551,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.12.0.tgz",
-      "integrity": "sha512-7F91fcbuDf/d3S8o21+r3ZncGIke/+eWk0EpO21LXhDfLahriZF9CGj4fbAetEjlaBdjdSm9a6VeXbpbT6Z40Q==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.14.1.tgz",
+      "integrity": "sha512-aAJd6bIf2vvQRjUG3ZkNXkmBpN+J7Wd0mfQiiVCJMu9Z5GcZZdcc0j8XwN/BM97Fl7e3SkTXODSk4VehUv7CGw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "7.12.0",
-        "@typescript-eslint/type-utils": "7.12.0",
-        "@typescript-eslint/utils": "7.12.0",
-        "@typescript-eslint/visitor-keys": "7.12.0",
+        "@typescript-eslint/scope-manager": "7.14.1",
+        "@typescript-eslint/type-utils": "7.14.1",
+        "@typescript-eslint/utils": "7.14.1",
+        "@typescript-eslint/visitor-keys": "7.14.1",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -1584,15 +1584,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.12.0.tgz",
-      "integrity": "sha512-dm/J2UDY3oV3TKius2OUZIFHsomQmpHtsV0FTh1WO8EKgHLQ1QCADUqscPgTpU+ih1e21FQSRjXckHn3txn6kQ==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.14.1.tgz",
+      "integrity": "sha512-8lKUOebNLcR0D7RvlcloOacTOWzOqemWEWkKSVpMZVF/XVcwjPR+3MD08QzbW9TCGJ+DwIc6zUSGZ9vd8cO1IA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.12.0",
-        "@typescript-eslint/types": "7.12.0",
-        "@typescript-eslint/typescript-estree": "7.12.0",
-        "@typescript-eslint/visitor-keys": "7.12.0",
+        "@typescript-eslint/scope-manager": "7.14.1",
+        "@typescript-eslint/types": "7.14.1",
+        "@typescript-eslint/typescript-estree": "7.14.1",
+        "@typescript-eslint/visitor-keys": "7.14.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1612,13 +1612,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.12.0.tgz",
-      "integrity": "sha512-itF1pTnN6F3unPak+kutH9raIkL3lhH1YRPGgt7QQOh43DQKVJXmWkpb+vpc/TiDHs6RSd9CTbDsc/Y+Ygq7kg==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.14.1.tgz",
+      "integrity": "sha512-gPrFSsoYcsffYXTOZ+hT7fyJr95rdVe4kGVX1ps/dJ+DfmlnjFN/GcMxXcVkeHDKqsq6uAcVaQaIi3cFffmAbA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.12.0",
-        "@typescript-eslint/visitor-keys": "7.12.0"
+        "@typescript-eslint/types": "7.14.1",
+        "@typescript-eslint/visitor-keys": "7.14.1"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -1629,13 +1629,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.12.0.tgz",
-      "integrity": "sha512-lib96tyRtMhLxwauDWUp/uW3FMhLA6D0rJ8T7HmH7x23Gk1Gwwu8UZ94NMXBvOELn6flSPiBrCKlehkiXyaqwA==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.14.1.tgz",
+      "integrity": "sha512-/MzmgNd3nnbDbOi3LfasXWWe292+iuo+umJ0bCCMCPc1jLO/z2BQmWUUUXvXLbrQey/JgzdF/OV+I5bzEGwJkQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.12.0",
-        "@typescript-eslint/utils": "7.12.0",
+        "@typescript-eslint/typescript-estree": "7.14.1",
+        "@typescript-eslint/utils": "7.14.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -1656,9 +1656,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.12.0.tgz",
-      "integrity": "sha512-o+0Te6eWp2ppKY3mLCU+YA9pVJxhUJE15FV7kxuD9jgwIAa+w/ycGJBMrYDTpVGUM/tgpa9SeMOugSabWFq7bg==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.14.1.tgz",
+      "integrity": "sha512-mL7zNEOQybo5R3AavY+Am7KLv8BorIv7HCYS5rKoNZKQD9tsfGUpO4KdAn3sSUvTiS4PQkr2+K0KJbxj8H9NDg==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -1669,13 +1669,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.12.0.tgz",
-      "integrity": "sha512-5bwqLsWBULv1h6pn7cMW5dXX/Y2amRqLaKqsASVwbBHMZSnHqE/HN4vT4fE0aFsiwxYvr98kqOWh1a8ZKXalCQ==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.14.1.tgz",
+      "integrity": "sha512-k5d0VuxViE2ulIO6FbxxSZaxqDVUyMbXcidC8rHvii0I56XZPv8cq+EhMns+d/EVIL41sMXqRbK3D10Oza1bbA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.12.0",
-        "@typescript-eslint/visitor-keys": "7.12.0",
+        "@typescript-eslint/types": "7.14.1",
+        "@typescript-eslint/visitor-keys": "7.14.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1697,15 +1697,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.12.0.tgz",
-      "integrity": "sha512-Y6hhwxwDx41HNpjuYswYp6gDbkiZ8Hin9Bf5aJQn1bpTs3afYY4GX+MPYxma8jtoIV2GRwTM/UJm/2uGCVv+DQ==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.14.1.tgz",
+      "integrity": "sha512-CMmVVELns3nak3cpJhZosDkm63n+DwBlDX8g0k4QUa9BMnF+lH2lr3d130M1Zt1xxmB3LLk3NV7KQCq86ZBBhQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "7.12.0",
-        "@typescript-eslint/types": "7.12.0",
-        "@typescript-eslint/typescript-estree": "7.12.0"
+        "@typescript-eslint/scope-manager": "7.14.1",
+        "@typescript-eslint/types": "7.14.1",
+        "@typescript-eslint/typescript-estree": "7.14.1"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -1719,12 +1719,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.12.0.tgz",
-      "integrity": "sha512-uZk7DevrQLL3vSnfFl5bj4sL75qC9D6EdjemIdbtkuUmIheWpuiiylSY01JxJE7+zGrOWDZrp1WxOuDntvKrHQ==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.14.1.tgz",
+      "integrity": "sha512-Crb+F75U1JAEtBeQGxSKwI60hZmmzaqA3z9sYsVm8X7W5cwLEm5bRe0/uXS6+MR/y8CVpKSR/ontIAIEPFcEkA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.12.0",
+        "@typescript-eslint/types": "7.14.1",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -1742,9 +1742,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
+      "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1763,10 +1763,13 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
-      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
+      "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
       "dev": true,
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2098,9 +2101,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001632",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001632.tgz",
-      "integrity": "sha512-udx3o7yHJfUxMLkGohMlVHCvFvWmirKh9JAH/d7WOLPetlH+LTL5cocMZ0t7oZx/mdlOWXti97xLZWc8uURRHg==",
+      "version": "1.0.30001637",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001637.tgz",
+      "integrity": "sha512-1x0qRI1mD1o9e+7mBI7XtzFAP4XszbHaVWsMiGbSPLYekKTJF7K+FNk6AsXH4sUpc+qrsI3pVgf1Jdl/uGkuSQ==",
       "dev": true,
       "funding": [
         {
@@ -2468,9 +2471,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.799",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.799.tgz",
-      "integrity": "sha512-3D3DwWkRTzrdEpntY0hMLYwj7SeBk1138CkPE8sBDSj3WzrzOiG2rHm3luw8jucpf+WiyLBCZyU9lMHyQI9M9Q==",
+      "version": "1.4.812",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.812.tgz",
+      "integrity": "sha512-7L8fC2Ey/b6SePDFKR2zHAy4mbdp1/38Yk5TsARO66W3hC5KEaeKMMHoxwtuH+jcu2AYLSn9QX04i95t6Fl1Hg==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2924,9 +2927,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/foreground-child": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.0.tgz",
-      "integrity": "sha512-CrWQNaEl1/6WeZoarcM9LHupTo3RpZO2Pdk1vktwzPiQTsJnAKJmm3TACKeG5UZbWDfaH2AbvYxzP96y0MT7fA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
+      "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
@@ -3259,12 +3262,15 @@
       "dev": true
     },
     "node_modules/is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.14.0.tgz",
+      "integrity": "sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==",
       "dev": true,
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4076,9 +4082,9 @@
       }
     },
     "node_modules/knowledge-html-converter": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/knowledge-html-converter/-/knowledge-html-converter-0.3.3.tgz",
-      "integrity": "sha512-xNG9coHsiE/IqFG71zj2q47flH0FKwtMQBvldDeRr19dh4Lk3u6RqdIOjjxq8LHVggySy0ews9xQlr9yOoVdew==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/knowledge-html-converter/-/knowledge-html-converter-0.3.4.tgz",
+      "integrity": "sha512-loX1GVRN6XQQ24ZIXXvMq+ikpi3qA89JCmGgDFv8D9LoGydcQTEojxaTilZYiies4xODiD8/xgfGApyUYpwr0g==",
       "dependencies": {
         "html-parse-stringify": "3.0.1",
         "sanitize-html": "2.12.1",
@@ -4247,9 +4253,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -4418,6 +4424,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+      "dev": true
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -4648,9 +4660,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.1.tgz",
-      "integrity": "sha512-7CAwy5dRsxs8PHXT3twixW9/OEll8MLE0VRPCJyl7CkS6VHGPSlsVaWTiASPTyGyYRyApxlaWTzwUxVNrhcwDg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
+      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -4859,15 +4871,16 @@
       }
     },
     "node_modules/rimraf/node_modules/glob": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
-      "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.2.tgz",
+      "integrity": "sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==",
       "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
         "minimatch": "^9.0.4",
         "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
         "path-scurry": "^1.11.1"
       },
       "bin": {
@@ -5301,9 +5314,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.1.4",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.4.tgz",
-      "integrity": "sha512-YiHwDhSvCiItoAgsKtoLFCuakDzDsJ1DLDnSouTaTmdOcOwIkSzbLXduaQ6M5DRVhuZC/NYaaZ/mtHbWMv/S6Q==",
+      "version": "29.1.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.5.tgz",
+      "integrity": "sha512-UuClSYxM7byvvYfyWdFI+/2UxMmwNyJb0NPkZPQE2hew3RurV7l7zURgOHAd/1I1ZdPpe3GUsXNXAcN8TFKSIg==",
       "dev": true,
       "dependencies": {
         "bs-logger": "0.x",
@@ -5439,9 +5452,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -5452,9 +5465,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.18.2.tgz",
-      "integrity": "sha512-o/MQLTwRm9IVhOqhZ0NQ9oXax1ygPjw6Vs+Vq/4QRjbOAC3B1GCHy7TYxxbExKlb7bzDRzt9vBWU6BDz0RFfYg==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.2.tgz",
+      "integrity": "sha512-JfjKqIauur3Q6biAtHJ564e3bWa8VvT+7cSiOJHFbX4Erv6CLGDpg8z+Fmg/1OI/47RA+GI2QZaF48SSaLvyBA==",
       "engines": {
         "node": ">=18.17"
       }
@@ -5510,9 +5523,9 @@
       "dev": true
     },
     "node_modules/v8-to-istanbul": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
-      "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-connector-app",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Knowledge Connector App",
   "module": "./dist/index.js",
   "main": "./dist/index.js",
@@ -56,24 +56,24 @@
     "@tsconfig/node18": "18.2.4",
     "@types/lodash": "4.17.5",
     "@types/node": "18.15.3",
-    "@typescript-eslint/eslint-plugin": "7.12.0",
-    "@typescript-eslint/parser": "7.12.0",
+    "@typescript-eslint/eslint-plugin": "7.14.1",
+    "@typescript-eslint/parser": "7.14.1",
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",
     "jest": "29.7.0",
-    "prettier": "3.3.1",
+    "prettier": "3.3.2",
     "rimraf": "5.0.7",
-    "ts-jest": "29.1.4",
+    "ts-jest": "29.1.5",
     "ts-jest-resolver": "2.0.1",
     "ts-node": "10.9.2",
     "tslib": "2.6.3",
-    "typescript": "5.4.5"
+    "typescript": "5.5.2"
   },
   "dependencies": {
     "dotenv": "16.4.5",
-    "knowledge-html-converter": "0.3.3",
+    "knowledge-html-converter": "0.3.4",
     "lodash": "4.17.21",
-    "undici": "6.18.2",
+    "undici": "6.19.2",
     "winston": "3.13.0"
   }
 }

--- a/src/aggregator/diff-aggregator.spec.ts
+++ b/src/aggregator/diff-aggregator.spec.ts
@@ -4,9 +4,9 @@ import { AdapterPair } from '../adapter/adapter-pair.js';
 import { Adapter } from '../adapter/adapter.js';
 import { SourceAdapter } from '../adapter/source-adapter.js';
 import {
-  generateCategory,
-  generateDocument,
-  generateLabel,
+  generateNormalizedCategory,
+  generateNormalizedDocument,
+  generateNormalizedLabel,
 } from '../tests/utils/entity-generators.js';
 import { GenesysDestinationAdapter } from '../genesys/genesys-destination-adapter.js';
 import {
@@ -66,15 +66,19 @@ describe('DiffAggregator', () => {
       it('should collect all entities to the created group', async () => {
         const importableContents = await aggregator.run({
           categories: [
-            generateCategory('1'),
-            generateCategory('2'),
-            generateCategory('3'),
+            generateNormalizedCategory('-1'),
+            generateNormalizedCategory('-2'),
+            generateNormalizedCategory('-3'),
           ],
-          labels: [generateLabel('1'), generateLabel('2'), generateLabel('3')],
+          labels: [
+            generateNormalizedLabel('-1'),
+            generateNormalizedLabel('-2'),
+            generateNormalizedLabel('-3'),
+          ],
           documents: [
-            generateDocument('1'),
-            generateDocument('2'),
-            generateDocument('3'),
+            generateNormalizedDocument('-1'),
+            generateNormalizedDocument('-2'),
+            generateNormalizedDocument('-3'),
           ],
         });
 
@@ -92,9 +96,18 @@ describe('DiffAggregator', () => {
             knowledgeBase: {
               id: '',
             },
-            categories: [generateCategory('1'), generateCategory('2')],
-            labels: [generateLabel('1'), generateLabel('2')],
-            documents: [generateDocument('1'), generateDocument('4')],
+            categories: [
+              generateNormalizedCategory('-1', 'category-id-1'),
+              generateNormalizedCategory('-2', 'category-id-2'),
+            ],
+            labels: [
+              generateNormalizedLabel('-1', 'label-id-1'),
+              generateNormalizedLabel('-2', 'label-id-2'),
+            ],
+            documents: [
+              generateNormalizedDocument('-1', 'document-id-1'),
+              generateNormalizedDocument('-4', 'document-id-4'),
+            ],
           },
         });
       });
@@ -102,19 +115,19 @@ describe('DiffAggregator', () => {
       it('should collect entities to the correct group', async () => {
         const importableContents = await aggregator.run({
           categories: [
-            generateCategory('1'),
-            generateCategory('2', 'updated-category'),
-            generateCategory('3'),
+            generateNormalizedCategory('-1'),
+            generateNormalizedCategory('-2', null, 'updated-category'),
+            generateNormalizedCategory('-3'),
           ],
           labels: [
-            generateLabel('1', 'updated-label'),
-            generateLabel('2'),
-            generateLabel('3'),
+            generateNormalizedLabel('-1', null, 'updated-label'),
+            generateNormalizedLabel('-2'),
+            generateNormalizedLabel('-3'),
           ],
           documents: [
-            generateDocument('1', 'updated-document'),
-            generateDocument('2'),
-            generateDocument('3'),
+            generateNormalizedDocument('-1', null, 'updated-document'),
+            generateNormalizedDocument('-2'),
+            generateNormalizedDocument('-3'),
           ],
         });
 
@@ -141,8 +154,18 @@ describe('DiffAggregator', () => {
               autocomplete: true,
             },
           ];
-          const doc1 = generateDocument('1', 'title1', doc1Alternatives);
-          const doc2 = generateDocument('2', 'title2', doc2Alternatives);
+          const doc1 = generateNormalizedDocument(
+            '-1',
+            null,
+            'title1',
+            doc1Alternatives,
+          );
+          const doc2 = generateNormalizedDocument(
+            '-2',
+            null,
+            'title2',
+            doc2Alternatives,
+          );
           mockExportAllEntities.mockResolvedValue({
             version: 3,
             importAction: {
@@ -161,8 +184,8 @@ describe('DiffAggregator', () => {
             categories: [],
             labels: [],
             documents: [
-              generateDocument('1', 'title1'),
-              generateDocument('2', 'updated title'),
+              generateNormalizedDocument('-1', null, 'title1'),
+              generateNormalizedDocument('-2', null, 'updated title'),
             ],
           });
 
@@ -185,8 +208,14 @@ describe('DiffAggregator', () => {
             categories: [],
             labels: [],
             documents: [
-              generateDocument('1', 'title1', null, false),
-              generateDocument('2', 'updated title', null, false),
+              generateNormalizedDocument('-1', null, 'title1', null, false),
+              generateNormalizedDocument(
+                '-2',
+                null,
+                'updated title',
+                null,
+                false,
+              ),
             ],
           });
 
@@ -208,9 +237,9 @@ describe('DiffAggregator', () => {
           it('should alter entity name with suffix', async () => {
             const importableContents = await aggregator.run({
               categories: [
-                generateCategory('1'),
-                generateCategory('not-2', 'category-name2'),
-                generateCategory('3'),
+                generateNormalizedCategory('-1'),
+                generateNormalizedCategory('-not-2', null, 'category-name-2'),
+                generateNormalizedCategory('-3'),
               ],
               labels: [],
               documents: [],
@@ -221,10 +250,10 @@ describe('DiffAggregator', () => {
             verifyGroups(importableContents.documents, 0, 0, 2);
 
             expect(importableContents.categories.created[0].name).toBe(
-              'category-name2-suffix',
+              'category-name-2-suffix',
             );
             expect(importableContents.categories.created[0].externalId).toBe(
-              'categories-not-2',
+              'category-external-id-not-2',
             );
           });
 
@@ -237,9 +266,9 @@ describe('DiffAggregator', () => {
                     id: '',
                   },
                   categories: [
-                    generateCategory('1'),
-                    generateCategory('2'),
-                    generateCategory('2-suffix'),
+                    generateNormalizedCategory('-1'),
+                    generateNormalizedCategory('-2'),
+                    generateNormalizedCategory('-2-suffix'),
                   ],
                   labels: [],
                   documents: [],
@@ -251,15 +280,19 @@ describe('DiffAggregator', () => {
               await expect(async () => {
                 await aggregator.run({
                   categories: [
-                    generateCategory('1'),
-                    generateCategory('not-2', 'category-name2'),
-                    generateCategory('3'),
+                    generateNormalizedCategory('-1'),
+                    generateNormalizedCategory(
+                      '-not-2',
+                      null,
+                      'category-name-2',
+                    ),
+                    generateNormalizedCategory('-3'),
                   ],
                   labels: [],
                   documents: [],
                 });
               }).rejects.toThrow(
-                'Name conflict found with suffix "category-name2-suffix". Try to use different "NAME_CONFLICT_SUFFIX" variable',
+                'Name conflict found with suffix "category-name-2-suffix". Try to use different "NAME_CONFLICT_SUFFIX" variable',
               );
             });
           });
@@ -269,12 +302,14 @@ describe('DiffAggregator', () => {
           it('should throw error', async () => {
             await expect(async () => {
               await aggregator.run({
-                categories: [generateCategory('not-2', 'category-name2')],
+                categories: [
+                  generateNormalizedCategory('-not-2', null, 'category-name-2'),
+                ],
                 labels: [],
                 documents: [],
               });
             }).rejects.toThrow(
-              'Name conflict found "category-name2". Try to use "NAME_CONFLICT_SUFFIX" variable',
+              'Name conflict found "category-name-2". Try to use "NAME_CONFLICT_SUFFIX" variable',
             );
           });
         });
@@ -295,8 +330,8 @@ describe('DiffAggregator', () => {
             const importableContents = await aggregator.run({
               categories: [],
               labels: [
-                generateLabel('1'),
-                generateLabel('not-2', 'label-name2'),
+                generateNormalizedLabel('-1'),
+                generateNormalizedLabel('-not-2', null, 'label-name-2'),
               ],
               documents: [],
             });
@@ -306,10 +341,10 @@ describe('DiffAggregator', () => {
             verifyGroups(importableContents.documents, 0, 0, 2);
 
             expect(importableContents.labels.created[0].name).toBe(
-              'label-name2-suffix',
+              'label-name-2-suffix',
             );
             expect(importableContents.labels.created[0].externalId).toBe(
-              'labels-not-2',
+              'label-external-id-not-2',
             );
           });
 
@@ -323,9 +358,9 @@ describe('DiffAggregator', () => {
                   },
                   categories: [],
                   labels: [
-                    generateLabel('1'),
-                    generateLabel('2'),
-                    generateLabel('2-suffix'),
+                    generateNormalizedLabel('-1'),
+                    generateNormalizedLabel('-2'),
+                    generateNormalizedLabel('-2-suffix'),
                   ],
                   documents: [],
                 },
@@ -337,14 +372,14 @@ describe('DiffAggregator', () => {
                 await aggregator.run({
                   categories: [],
                   labels: [
-                    generateLabel('1'),
-                    generateLabel('not-2', 'label-name2'),
-                    generateLabel('3'),
+                    generateNormalizedLabel('-1'),
+                    generateNormalizedLabel('-not-2', null, 'label-name-2'),
+                    generateNormalizedLabel('-3'),
                   ],
                   documents: [],
                 });
               }).rejects.toThrow(
-                'Name conflict found with suffix "label-name2-suffix". Try to use different "NAME_CONFLICT_SUFFIX" variable',
+                'Name conflict found with suffix "label-name-2-suffix". Try to use different "NAME_CONFLICT_SUFFIX" variable',
               );
             });
           });
@@ -354,12 +389,14 @@ describe('DiffAggregator', () => {
           it('should throw error', async () => {
             await expect(async () => {
               await aggregator.run({
-                categories: [generateCategory('not-2', 'category-name2')],
+                categories: [
+                  generateNormalizedCategory('-not-2', null, 'category-name-2'),
+                ],
                 labels: [],
                 documents: [],
               });
             }).rejects.toThrow(
-              'Name conflict found "category-name2". Try to use "NAME_CONFLICT_SUFFIX" variable',
+              'Name conflict found "category-name-2". Try to use "NAME_CONFLICT_SUFFIX" variable',
             );
           });
         });
@@ -377,19 +414,70 @@ describe('DiffAggregator', () => {
               id: '',
             },
             categories: [
-              generateCategory('1', 'category-source1', source1),
-              generateCategory('1', 'category-source2', source2),
-              generateCategory('2', 'category-del-source2', source2),
+              generateNormalizedCategory(
+                '',
+                'category-id-1',
+                'category-source1',
+                `${source1}-category-external-id-1`,
+              ),
+              generateNormalizedCategory(
+                '',
+                'category-id-2',
+                'category-source2',
+                `${source2}-category-external-id-1`,
+              ),
+              generateNormalizedCategory(
+                '',
+                'category-id-3',
+                'category-del-source2',
+                `${source2}-category-external-id-2`,
+              ),
             ],
             labels: [
-              generateLabel('1', 'label-source1', source1),
-              generateLabel('1', 'label-source2', source2),
-              generateLabel('2', 'label-del-source2', source2),
+              generateNormalizedLabel(
+                '',
+                'label-id-1',
+                'label-source1',
+                `${source1}-label-external-id-1`,
+              ),
+              generateNormalizedLabel(
+                '',
+                'label-id-2',
+                'label-source2',
+                `${source2}-label-external-id-2`,
+              ),
+              generateNormalizedLabel(
+                '',
+                'label-id-3',
+                'label-del-source2',
+                `${source2}-label-external-id-3`,
+              ),
             ],
             documents: [
-              generateDocument('1', 'document-source1', [], true, source1),
-              generateDocument('1', 'document-source2', [], true, source2),
-              generateDocument('2', 'document-del-source2', [], true, source2),
+              generateNormalizedDocument(
+                '-1',
+                'document-id-1',
+                'document-source1',
+                [],
+                true,
+                `${source1}-article-external-id-1`,
+              ),
+              generateNormalizedDocument(
+                '-1',
+                'document-id-2',
+                'document-source2',
+                [],
+                true,
+                `${source2}-article-external-id-1`,
+              ),
+              generateNormalizedDocument(
+                '-2',
+                'document-id-3',
+                'document-del-source2',
+                [],
+                true,
+                `${source2}-article-external-id-2`,
+              ),
             ],
           },
         });
@@ -400,16 +488,50 @@ describe('DiffAggregator', () => {
       it('should collect entities to the correct group', async () => {
         const importableContents = await aggregator.run({
           categories: [
-            generateCategory('1', 'category-update', source2),
-            generateCategory('3', 'category-new', source2),
+            generateNormalizedCategory(
+              '-1',
+              null,
+              'category-update',
+              `${source2}-category-external-id-1`,
+            ),
+            generateNormalizedCategory(
+              '-3',
+              null,
+              'category-new',
+              `${source2}-category-external-id-3`,
+            ),
           ],
           labels: [
-            generateLabel('1', 'label-update', source2),
-            generateLabel('3', 'label-new', source2),
+            generateNormalizedLabel(
+              '',
+              'label-id-1',
+              'label-update',
+              `${source2}-label-external-id-1`,
+            ),
+            generateNormalizedLabel(
+              '',
+              'label-id-3',
+              'label-new',
+              `${source2}-label-external-id-3`,
+            ),
           ],
           documents: [
-            generateDocument('1', 'document-update', [], true, source2),
-            generateDocument('3', 'document-new', [], true, source2),
+            generateNormalizedDocument(
+              '-1',
+              null,
+              'document-update',
+              [],
+              true,
+              `${source2}-article-external-id-1`,
+            ),
+            generateNormalizedDocument(
+              '-3',
+              null,
+              'document-new',
+              [],
+              true,
+              `${source2}-article-external-id-3`,
+            ),
           ],
         });
 

--- a/src/aggregator/diff-aggregator.ts
+++ b/src/aggregator/diff-aggregator.ts
@@ -149,7 +149,7 @@ export class DiffAggregator implements Aggregator {
     const { title, alternatives, visible, category, labels, variations } =
       documentVersion;
     return {
-      title,
+      title: title ? title.trim() : title,
       alternatives: alternatives ?? null,
       visible,
       category: category ? this.normalizeCategoryReference(category) : null,

--- a/src/pipe/abstract-loader.ts
+++ b/src/pipe/abstract-loader.ts
@@ -1,0 +1,33 @@
+import { Loader } from './loader.js';
+import { AdapterPair } from '../adapter/adapter-pair.js';
+import { Adapter } from '../adapter/adapter.js';
+import { ExternalContent } from '../model';
+import { Config } from '../config.js';
+import { LoaderConfig } from './loader-config.js';
+
+export abstract class AbstractLoader implements Loader {
+  private _config: LoaderConfig = {};
+
+  public async initialize(
+    config: Config,
+    _adapters: AdapterPair<Adapter, Adapter>,
+  ): Promise<void> {
+    this._config = config;
+  }
+
+  public abstract run(
+    input: ExternalContent | undefined,
+  ): Promise<ExternalContent>;
+
+  protected shouldLoadArticles(): boolean {
+    return this._config.fetchArticles !== 'false';
+  }
+
+  protected shouldLoadCategories(): boolean {
+    return this._config.fetchCategories !== 'false';
+  }
+
+  protected shouldLoadLabels(): boolean {
+    return this._config.fetchLabels !== 'false';
+  }
+}

--- a/src/pipe/loader-config.ts
+++ b/src/pipe/loader-config.ts
@@ -1,0 +1,7 @@
+import { Config } from '../config.js';
+
+export interface LoaderConfig extends Config {
+  fetchCategories?: string;
+  fetchLabels?: string;
+  fetchArticles?: string;
+}

--- a/src/pipe/pipe.ts
+++ b/src/pipe/pipe.ts
@@ -30,7 +30,6 @@ export class Pipe {
   private processorList: Processor[] = [];
   private aggregatorList: Aggregator[] = [];
   private uploaderList: Uploader[] = [];
-  private configurerFn: Configurer | undefined;
 
   /**
    * Define source and destination adapters
@@ -97,7 +96,7 @@ export class Pipe {
   }
 
   public configurer(configurer: Configurer): Pipe {
-    this.configurerFn = configurer;
+    configurer(this);
     return this;
   }
 
@@ -110,10 +109,6 @@ export class Pipe {
     const killTimer = this.startProcessKillTimer(config);
 
     try {
-      if (this.configurerFn) {
-        this.configurerFn(this);
-      }
-
       validateNonNull(this.sourceAdapter, 'Missing source adapter');
       validateNonNull(this.destinationAdapter, 'Missing destination adapter');
 

--- a/src/processor/image-processor.spec.ts
+++ b/src/processor/image-processor.spec.ts
@@ -2,7 +2,10 @@ import { AdapterPair } from '../adapter/adapter-pair.js';
 import { ImageProcessor } from './image-processor.js';
 import { ImageSourceAdapter } from '../adapter/image-source-adapter.js';
 import { GenesysDestinationAdapter } from '../genesys/genesys-destination-adapter.js';
-import { generateDocument, generateDocumentWithTable } from '../tests/utils/entity-generators.js';
+import {
+  generateDocumentWithTable,
+  generateNormalizedDocument,
+} from '../tests/utils/entity-generators.js';
 import { Image } from '../model/image.js';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
@@ -57,9 +60,9 @@ describe('ImageProcessor', () => {
         categories: [],
         labels: [],
         documents: [
-          generateDocument('1'),
-          generateDocument('2'),
-          generateDocument('3'),
+          generateNormalizedDocument('1'),
+          generateNormalizedDocument('2'),
+          generateNormalizedDocument('3'),
         ],
       });
 
@@ -72,16 +75,16 @@ describe('ImageProcessor', () => {
       const result = await imageProcessor.run({
         categories: [],
         labels: [],
-        documents: [
-          generateDocumentWithTable('1'),
-        ],
+        documents: [generateDocumentWithTable('1')],
       });
 
       expect(
-        result.documents[0].published?.variations[0].body?.blocks[1].table?.rows[0].cells[0].blocks[0].image?.url,
+        result.documents[0].published?.variations[0].body?.blocks[1].table
+          ?.rows[0].cells[0].blocks[0].image?.url,
       ).toBe('https://api.mypurecloud.com/image');
       expect(
-        result.documents[0].published?.variations[0].body?.blocks[1].table?.rows[1].cells[0].blocks[0].image?.url,
+        result.documents[0].published?.variations[0].body?.blocks[1].table
+          ?.rows[1].cells[0].blocks[0].image?.url,
       ).toBe('https://api.mypurecloud.com/image');
     });
   });

--- a/src/processor/prefix-external-id.spec.ts
+++ b/src/processor/prefix-external-id.spec.ts
@@ -4,9 +4,9 @@ import { AdapterPair } from '../adapter/adapter-pair.js';
 import { Config } from '../config.js';
 import { ExternalContent } from '../model/external-content.js';
 import {
-  generateCategory,
-  generateDocument,
-  generateLabel,
+  generateNormalizedCategory,
+  generateNormalizedDocument,
+  generateNormalizedLabel,
 } from '../tests/utils/entity-generators.js';
 import { beforeEach, describe, expect, it } from '@jest/globals';
 
@@ -43,16 +43,41 @@ describe('PrefixExternalId', () => {
 
   it('should add prefix to all entities', async () => {
     const content: ExternalContent = {
-      labels: [generateLabel('1'), generateLabel('2'), generateLabel('3')],
+      labels: [
+        generateNormalizedLabel('-1', undefined, undefined, 'labels-1'),
+        generateNormalizedLabel('-2', undefined, undefined, 'labels-2'),
+        generateNormalizedLabel('-3', undefined, undefined, 'labels-3'),
+      ],
       categories: [
-        generateCategory('1'),
-        generateCategory('2'),
-        generateCategory('3'),
+        generateNormalizedCategory('-1', undefined, undefined, 'categories-1'),
+        generateNormalizedCategory('-2', undefined, undefined, 'categories-2'),
+        generateNormalizedCategory('-3', undefined, undefined, 'categories-3'),
       ],
       documents: [
-        generateDocument('1'),
-        generateDocument('2'),
-        generateDocument('3'),
+        generateNormalizedDocument(
+          '-1',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          'documents-1',
+        ),
+        generateNormalizedDocument(
+          '-2',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          'documents-2',
+        ),
+        generateNormalizedDocument(
+          '-3',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          'documents-3',
+        ),
       ],
     };
 

--- a/src/salesforce/content-mapper.spec.ts
+++ b/src/salesforce/content-mapper.spec.ts
@@ -4,7 +4,7 @@ import { contentMapper } from './content-mapper.js';
 describe('contentMapper', () => {
   describe('article mapper', () => {
     it('should exclude none text fields', () => {
-      const result = contentMapper([], [buildArticle()], []);
+      const result = contentMapper([], [buildArticle()], [], false);
 
       expect(result.documents[0].published?.title).toBe('the title');
       expect(result.documents[0].published?.variations[0].rawHtml).toBe(
@@ -17,6 +17,7 @@ describe('contentMapper', () => {
         [],
         [buildArticle()],
         ['layout item name 5'],
+        false,
       );
 
       expect(result.documents[0].published?.title).toBe('the title');

--- a/src/salesforce/content-mapper.ts
+++ b/src/salesforce/content-mapper.ts
@@ -13,6 +13,7 @@ export function contentMapper(
   categoryGroups: SalesforceCategoryGroup[],
   articles: SalesforceArticleDetails[],
   salesforceArticleContentFields: string[],
+  fetchCategories: boolean,
 ): ExternalContent {
   const labelsMapping = buildIdAndNameMapping(categoryGroups);
 
@@ -26,7 +27,12 @@ export function contentMapper(
     categories: [],
     documents: articles
       ? articles.map((a) =>
-          articleMapper(a, labelsMapping, salesforceArticleContentFields),
+          articleMapper(
+            a,
+            labelsMapping,
+            salesforceArticleContentFields,
+            fetchCategories,
+          ),
         )
       : [],
   };
@@ -75,15 +81,19 @@ function articleMapper(
   article: SalesforceArticleDetails,
   labelIdAndNameMapping: Map<string, string>,
   salesforceArticleContentFields: string[],
+  fetchCategories: boolean,
 ): Document {
   const { id, title, categoryGroups, layoutItems } = article;
 
-  const labels: LabelReference[] = categoryGroups.flatMap((categoryGroup) =>
-    categoryGroup.selectedCategories.map((category) => {
-      const name = labelIdAndNameMapping.get(category.url);
-      return { id: null, name: name! };
-    }),
-  );
+  let labels: LabelReference[] | null = null;
+  if (fetchCategories) {
+    labels = categoryGroups.flatMap((categoryGroup) =>
+      categoryGroup.selectedCategories.map((category) => {
+        const name = labelIdAndNameMapping.get(category.url);
+        return { id: null, name: name! };
+      }),
+    );
+  }
 
   const documentVersion: DocumentVersion = {
     visible: true,

--- a/src/salesforce/model/salesforce-category.ts
+++ b/src/salesforce/model/salesforce-category.ts
@@ -1,5 +1,5 @@
 export interface SalesforceCategory {
-  childCategories: SalesforceCategory[];
+  childCategories?: SalesforceCategory[];
   label: string;
   name: string;
   url: string;

--- a/src/salesforce/salesforce-loader.spec.ts
+++ b/src/salesforce/salesforce-loader.spec.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Adapter } from '../adapter/adapter.js';
+import { Image } from '../model';
+import { SalesforceAdapter } from './salesforce-adapter.js';
+import { SalesforceConfig } from './model/salesforce-config.js';
+import { SalesforceLoader } from './salesforce-loader.js';
+import { SalesforceArticleDetails } from './model/salesforce-article-details';
+import { generateRawDocument } from '../tests/utils/entity-generators.js';
+import { SalesforceCategoryGroup } from './model/salesforce-category-group.js';
+
+const mockGetAllArticles = jest.fn<() => Promise<SalesforceArticleDetails[]>>();
+const mockGetAttachment =
+  jest.fn<(articleId: string | null, url: string) => Promise<Image | null>>();
+const mockGetAllCategories =
+  jest.fn<() => Promise<SalesforceCategoryGroup[]>>();
+const mockGetAllLabels = jest.fn<() => Promise<unknown[]>>();
+
+describe('SalesforceLoader', () => {
+  const LABEL = generateMappedLabel();
+  const DOCUMENT = generateRawDocument(
+    '<p><img src="/null/richTextImageFields//null"></p>',
+    null,
+    [
+      {
+        id: null,
+        name: 'category-group-label/category-label',
+      },
+    ],
+  );
+
+  let config: SalesforceConfig;
+  let adapter: SalesforceAdapter;
+  let loader: SalesforceLoader;
+
+  beforeEach(async () => {
+    config = {
+      salesforceLoginUrl: 'https://login-url',
+      salesforceApiVersion: 'v56.0',
+      salesforceClientId: 'client-id',
+      salesforceClientSecret: 'client-secret',
+      salesforceUsername: 'username',
+      salesforcePassword: 'password',
+    };
+    adapter = new SalesforceAdapter();
+    loader = new SalesforceLoader();
+
+    mockGetAllArticles.mockResolvedValueOnce([generateArticle()]);
+    mockGetAllCategories.mockResolvedValueOnce([generateCategory()]);
+  });
+
+  describe('run', () => {
+    beforeEach(async () => {
+      await loader.initialize(config, {
+        sourceAdapter: adapter,
+        destinationAdapter: {} as Adapter,
+      });
+    });
+
+    it('should fetch articles and categories only', async () => {
+      await loader.run();
+
+      expect(mockGetAllArticles).toHaveBeenCalled();
+      expect(mockGetAllCategories).toHaveBeenCalled();
+      expect(mockGetAllLabels).not.toHaveBeenCalled();
+    });
+
+    it('should map entities', async () => {
+      const result = await loader.run();
+
+      expect(result).toEqual({
+        labels: [LABEL],
+        documents: [DOCUMENT],
+        categories: [],
+      });
+    });
+
+    describe('when categories excluded', () => {
+      beforeEach(async () => {
+        await loader.initialize(
+          { ...config, fetchCategories: 'false' },
+          {
+            sourceAdapter: adapter,
+            destinationAdapter: {} as Adapter,
+          },
+        );
+      });
+
+      it('should leave labels (=categories) empty', async () => {
+        const result = await loader.run();
+
+        expect(result).toEqual({
+          labels: [],
+          documents: [
+            generateRawDocument(
+              '<p><img src="/null/richTextImageFields//null"></p>',
+              null,
+              null,
+            ),
+          ],
+          categories: [],
+        });
+        expect(mockGetAllCategories).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when articles excluded', () => {
+      beforeEach(async () => {
+        await loader.initialize(
+          { ...config, fetchArticles: 'false' },
+          {
+            sourceAdapter: adapter,
+            destinationAdapter: {} as Adapter,
+          },
+        );
+      });
+
+      it('should leave documents empty', async () => {
+        const result = await loader.run();
+
+        expect(result).toEqual({
+          labels: [LABEL],
+          documents: [],
+          categories: [],
+        });
+        expect(mockGetAllArticles).not.toHaveBeenCalled();
+      });
+    });
+  });
+});
+
+jest.mock('./salesforce-adapter.js', () => {
+  return {
+    SalesforceAdapter: jest.fn().mockImplementation(() => {
+      return {
+        initialise: jest.fn<(config: SalesforceConfig) => Promise<void>>(),
+        getAllArticles: () => mockGetAllArticles(),
+        getAttachment: (articleId: string | null, url: string) =>
+          mockGetAttachment(articleId, url),
+        getAllCategories: () => mockGetAllCategories(),
+        getAllLabels: () => mockGetAllLabels(),
+      };
+    }),
+  };
+});
+
+function generateArticle(): SalesforceArticleDetails {
+  return {
+    id: 'article-external-id',
+    title: 'article-title',
+    categoryGroups: [
+      {
+        label: 'category-group-label',
+        name: 'category-group-name',
+        topCategories: [],
+        selectedCategories: [
+          {
+            label: 'category-label',
+            name: 'category-name',
+            url: 'category-url',
+          },
+        ],
+      },
+    ],
+    layoutItems: [
+      {
+        type: 'RICH_TEXT_AREA',
+        value: '<img src="https://document-image.url">',
+        label: '',
+        name: '',
+      },
+    ],
+  };
+}
+
+function generateCategory(): SalesforceCategoryGroup {
+  return {
+    label: 'category-group-label',
+    name: 'category-group-name',
+    topCategories: [
+      {
+        childCategories: [],
+        label: 'category-label',
+        name: 'category-name',
+        url: 'category-url',
+      },
+    ],
+    selectedCategories: [],
+  };
+}
+
+function generateMappedLabel() {
+  return {
+    color: 'generated-value-color',
+    externalId: 'category-url',
+    id: null,
+    name: 'category-group-label/category-label',
+  };
+}

--- a/src/servicenow/configurer.ts
+++ b/src/servicenow/configurer.ts
@@ -8,7 +8,7 @@ import { DiffUploader } from '../uploader/diff-uploader.js';
 import { ServiceNowAdapter } from './servicenow-adapter.js';
 import { ServiceNowLoader } from './servicenow-loader.js';
 
-export const configurer: Configurer = (pipe: Pipe) => {
+export const configurer: Configurer = (pipe: Pipe): void => {
   pipe
     .source(new ServiceNowAdapter())
     .loaders(new ServiceNowLoader())

--- a/src/servicenow/content-mapper.ts
+++ b/src/servicenow/content-mapper.ts
@@ -4,7 +4,10 @@ import { ServiceNowArticle } from './model/servicenow-article.js';
 import { Category } from '../model/category.js';
 import { CategoryReference } from '../model/category-reference.js';
 
-export function contentMapper(articles: ServiceNowArticle[]): ExternalContent {
+export function contentMapper(
+  articles: ServiceNowArticle[],
+  fetchCategories: boolean,
+): ExternalContent {
   return {
     categories: articles
       ? [
@@ -18,7 +21,9 @@ export function contentMapper(articles: ServiceNowArticle[]): ExternalContent {
       : [],
     labels: [],
     documents: articles
-      ? articles.map((a: ServiceNowArticle) => articleMapper(a))
+      ? articles.map((a: ServiceNowArticle) =>
+          articleMapper(a, fetchCategories),
+        )
       : [],
   };
 }
@@ -27,7 +32,10 @@ function categoryMapper(article: ServiceNowArticle): Category[] {
   return getCategoryWithParent(article);
 }
 
-function articleMapper(article: ServiceNowArticle): Document {
+function articleMapper(
+  article: ServiceNowArticle,
+  fetchCategories: boolean,
+): Document {
   const id = article.id;
   const title = article.title;
   const body = article.fields.text.value;
@@ -43,7 +51,7 @@ function articleMapper(article: ServiceNowArticle): Document {
         body: null,
       },
     ],
-    category: getCategoryReference(article),
+    category: fetchCategories ? getCategoryReference(article) : null,
     labels: null,
   };
 
@@ -111,5 +119,10 @@ function getCategoryReference(
 ): CategoryReference | null {
   const { category } = getCategory(article);
 
-  return category || null;
+  if (!category) {
+    return null;
+  }
+
+  const { id, name } = category;
+  return { id, name };
 }

--- a/src/servicenow/servicenow-adapter.ts
+++ b/src/servicenow/servicenow-adapter.ts
@@ -58,17 +58,17 @@ export class ServiceNowAdapter
     };
   }
 
-  private async getAttachmentInfo(
-    attachmentId: string,
-  ): Promise<ServiceNowArticleAttachment | undefined> {
-    return this.api.fetchAttachmentInfo(attachmentId);
-  }
-
   public getAllCategories(): Promise<unknown[]> {
     return Promise.reject();
   }
 
   public getAllLabels(): Promise<unknown[]> {
     return Promise.reject();
+  }
+
+  private async getAttachmentInfo(
+    attachmentId: string,
+  ): Promise<ServiceNowArticleAttachment | undefined> {
+    return this.api.fetchAttachmentInfo(attachmentId);
   }
 }

--- a/src/servicenow/servicenow-loader.spec.ts
+++ b/src/servicenow/servicenow-loader.spec.ts
@@ -1,0 +1,169 @@
+import { ServiceNowConfig } from './model/servicenow-config.js';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { ServiceNowAdapter } from './servicenow-adapter.js';
+import { ServiceNowLoader } from './servicenow-loader.js';
+import { Adapter } from '../adapter/adapter.js';
+import { ServiceNowArticle } from './model/servicenow-article.js';
+import { Image } from '../model';
+import {
+  generateNormalizedCategory,
+  generateRawDocument,
+} from '../tests/utils/entity-generators';
+
+const mockGetAllArticles = jest.fn<() => Promise<ServiceNowArticle[]>>();
+const mockGetAttachment =
+  jest.fn<(articleId: string | null, url: string) => Promise<Image | null>>();
+const mockGetAllCategories = jest.fn<() => Promise<unknown[]>>();
+const mockGetAllLabels = jest.fn<() => Promise<unknown[]>>();
+
+describe('ServiceNowLoader', () => {
+  const CATEGORY = generateNormalizedCategory(
+    '',
+    null,
+    'category-display-value',
+    'topic-valuecategory-value',
+    {
+      id: null,
+      name: 'topic-display-value',
+    },
+  );
+  const TOPIC = generateNormalizedCategory(
+    '',
+    null,
+    'topic-display-value',
+    'topic-value',
+  );
+  const DOCUMENT = generateRawDocument('<p>article body</p>', {
+    id: null,
+    name: 'category-display-value',
+  });
+
+  let config: ServiceNowConfig;
+  let adapter: ServiceNowAdapter;
+  let loader: ServiceNowLoader;
+
+  beforeEach(async () => {
+    config = {
+      servicenowUsername: 'user',
+      servicenowPassword: 'password',
+      servicenowBaseUrl: 'https://test-url.com',
+    };
+    adapter = new ServiceNowAdapter();
+    loader = new ServiceNowLoader();
+
+    mockGetAllArticles.mockResolvedValueOnce([generateArticle()]);
+  });
+
+  describe('run', () => {
+    beforeEach(async () => {
+      await loader.initialize(config, {
+        sourceAdapter: adapter,
+        destinationAdapter: {} as Adapter,
+      });
+    });
+
+    it('should fetch articles only', async () => {
+      await loader.run();
+
+      expect(mockGetAllArticles).toHaveBeenCalled();
+      expect(mockGetAllLabels).not.toHaveBeenCalled();
+      expect(mockGetAllCategories).not.toHaveBeenCalled();
+    });
+
+    it('should map entities', async () => {
+      const result = await loader.run();
+
+      expect(result).toEqual({
+        labels: [],
+        documents: [DOCUMENT],
+        categories: [CATEGORY, TOPIC],
+      });
+    });
+
+    describe('when categories excluded', () => {
+      beforeEach(async () => {
+        await loader.initialize(
+          { ...config, fetchCategories: 'false' },
+          {
+            sourceAdapter: adapter,
+            destinationAdapter: {} as Adapter,
+          },
+        );
+      });
+
+      it('should leave categories empty', async () => {
+        const result = await loader.run();
+
+        expect(result).toEqual({
+          labels: [],
+          documents: [generateRawDocument('<p>article body</p>')],
+          categories: [],
+        });
+      });
+    });
+
+    describe('when articles excluded', () => {
+      beforeEach(async () => {
+        await loader.initialize(
+          { ...config, fetchArticles: 'false' },
+          {
+            sourceAdapter: adapter,
+            destinationAdapter: {} as Adapter,
+          },
+        );
+      });
+
+      it('should leave documents empty', async () => {
+        const result = await loader.run();
+
+        expect(result).toEqual({
+          labels: [],
+          documents: [],
+          categories: [CATEGORY, TOPIC],
+        });
+      });
+    });
+  });
+});
+
+jest.mock('./servicenow-adapter.js', () => {
+  return {
+    ServiceNowAdapter: jest.fn().mockImplementation(() => {
+      return {
+        initialise: jest.fn<(config: ServiceNowConfig) => Promise<void>>(),
+        getAllArticles: () => mockGetAllArticles(),
+        getAttachment: (articleId: string | null, url: string) =>
+          mockGetAttachment(articleId, url),
+        getAllCategories: () => mockGetAllCategories(),
+        getAllLabels: () => mockGetAllLabels(),
+      };
+    }),
+  };
+});
+
+function generateArticle(): ServiceNowArticle {
+  return {
+    link: 'article-link',
+    id: 'article-external-id',
+    title: 'article-title',
+    snippet: 'article-snippet',
+    fields: {
+      category: {
+        name: 'category-name',
+        value: 'category-value',
+        display_value: 'category-display-value',
+      },
+      topic: {
+        name: 'topic-name',
+        value: 'topic-value',
+        display_value: 'topic-display-value',
+      },
+      text: {
+        value: '<p>article body</p>',
+      },
+      workflow_state: {
+        value: 'published',
+      },
+    },
+  };
+}

--- a/src/servicenow/servicenow-loader.ts
+++ b/src/servicenow/servicenow-loader.ts
@@ -1,4 +1,3 @@
-import { Loader } from '../pipe/loader.js';
 import { ServiceNowAdapter } from './servicenow-adapter.js';
 import { ExternalContent } from '../model/external-content.js';
 import { contentMapper } from './content-mapper.js';
@@ -7,17 +6,20 @@ import { AdapterPair } from '../adapter/adapter-pair.js';
 import { Adapter } from '../adapter/adapter.js';
 import { validateNonNull } from '../utils/validate-non-null.js';
 import { getLogger } from '../utils/logger.js';
+import { AbstractLoader } from '../pipe/abstract-loader.js';
 
 /**
  * ServiceNow is a specific {@Link Loader} implementation for fetching data from ServiceNow API
  */
-export class ServiceNowLoader implements Loader {
+export class ServiceNowLoader extends AbstractLoader {
   private adapter?: ServiceNowAdapter;
 
   public async initialize(
     _config: ServiceNowConfig,
     adapters: AdapterPair<ServiceNowAdapter, Adapter>,
   ): Promise<void> {
+    await super.initialize(_config, adapters);
+
     this.adapter = adapters.sourceAdapter;
   }
 
@@ -27,7 +29,14 @@ export class ServiceNowLoader implements Loader {
     getLogger().info('Fetching data...');
     const articles = await this.adapter!.getAllArticles();
 
-    const data = contentMapper(articles);
+    const data = contentMapper(articles, this.shouldLoadCategories());
+
+    if (!this.shouldLoadArticles()) {
+      data.documents = [];
+    }
+    if (!this.shouldLoadCategories()) {
+      data.categories = [];
+    }
 
     getLogger().info('Categories loaded: ' + data.categories.length);
     getLogger().info('Documents loaded: ' + data.documents.length);

--- a/src/tests/utils/entity-generators.ts
+++ b/src/tests/utils/entity-generators.ts
@@ -1,45 +1,49 @@
 import { Label } from '../../model/label.js';
 import { Category } from '../../model/category.js';
 import { Document } from '../../model/sync-export-model.js';
-import { SyncableContents } from '../../model/syncable-contents.js';
 import { DocumentAlternative } from '../../model/document-alternative.js';
+import { CategoryReference, LabelReference } from '../../model';
 
-export function generateLabel(
+export function generateNormalizedLabel(
   suffix: string,
-  name = 'label-name' + suffix,
-  externalIdPrefix: string = '',
+  id: string | null = null,
+  name: string = 'label-name' + suffix,
+  externalId: string = 'label-external-id' + suffix,
 ): Label {
   return {
-    id: '',
+    id,
     name,
-    externalId: externalIdPrefix + 'labels-' + suffix,
-    color: '',
+    externalId,
+    color: 'generated-value-color',
   };
 }
 
-export function generateCategory(
+export function generateNormalizedCategory(
   suffix: string,
-  name = 'category-name' + suffix,
-  externalIdPrefix: string = '',
+  id: string | null = null,
+  name: string = 'category-name' + suffix,
+  externalId: string = 'category-external-id' + suffix,
+  parentCategory: CategoryReference | null = null,
 ): Category {
   return {
-    id: '',
+    id,
     name,
-    externalId: externalIdPrefix + 'categories-' + suffix,
-    parentCategory: null,
+    externalId,
+    parentCategory,
   };
 }
 
-export function generateDocument(
+export function generateNormalizedDocument(
   suffix: string,
-  title = 'document-name' + suffix,
+  id: string | null = null,
+  title = 'article-title' + suffix,
   alternatives: DocumentAlternative[] | null = null,
   visible: boolean = true,
-  externalIdPrefix: string = '',
+  externalId: string = 'article-external-id' + suffix,
 ): Document {
   return {
-    id: '',
-    externalId: externalIdPrefix + 'documents-' + suffix,
+    id,
+    externalId,
     published: {
       title,
       visible,
@@ -65,15 +69,12 @@ export function generateDocument(
   };
 }
 
-export function generateDocumentWithTable(
-  suffix: string,
-  title = 'document-name' + suffix,
-): Document {
+export function generateDocumentWithTable(suffix: string): Document {
   return {
     id: '',
     externalId: 'documents-' + suffix,
     published: {
-      title,
+      title: 'document-title' + suffix,
       visible: true,
       alternatives: null,
       variations: [
@@ -171,27 +172,27 @@ export function generateDocumentWithTable(
   };
 }
 
-export function generateImportableContents(
-  override: Partial<SyncableContents>,
-): SyncableContents {
+export function generateRawDocument(
+  rawHtml: string = '',
+  category: CategoryReference | null = null,
+  labels: LabelReference[] | null = null,
+): Document {
   return {
-    labels: {
-      created: [],
-      updated: [],
-      deleted: [],
-      ...(override.labels || {}),
+    id: null,
+    externalId: 'article-external-id',
+    published: {
+      title: 'article-title',
+      visible: true,
+      alternatives: null,
+      variations: [
+        {
+          body: null,
+          rawHtml,
+        },
+      ],
+      category,
+      labels,
     },
-    categories: {
-      created: [],
-      updated: [],
-      deleted: [],
-      ...(override.categories || {}),
-    },
-    documents: {
-      created: [],
-      updated: [],
-      deleted: [],
-      ...(override.documents || {}),
-    },
+    draft: null,
   };
 }

--- a/src/zendesk/content-mapper.ts
+++ b/src/zendesk/content-mapper.ts
@@ -12,6 +12,8 @@ export function contentMapper(
   categories: ZendeskSection[],
   labels: ZendeskLabel[],
   articles: ZendeskArticle[],
+  fetchCategories: boolean,
+  fetchLabels: boolean,
 ): ExternalContent {
   const sectionIdAndNameMapping = buildIdAndNameMapping(categories);
 
@@ -21,7 +23,14 @@ export function contentMapper(
       : [],
     labels: labels ? labels.map(labelMapper) : [],
     documents: articles
-      ? articles.map((a) => articleMapper(a, sectionIdAndNameMapping))
+      ? articles.map((a) =>
+          articleMapper(
+            a,
+            sectionIdAndNameMapping,
+            fetchCategories,
+            fetchLabels,
+          ),
+        )
       : [],
   };
 }
@@ -64,6 +73,8 @@ function labelMapper(label: ZendeskLabel): Label {
 function articleMapper(
   article: ZendeskArticle,
   sectionIdAndNameMapping: Map<string, string>,
+  fetchCategories: boolean,
+  fetchLabels: boolean,
 ): Document {
   const { id, title, body, draft, section_id, label_names } = article;
 
@@ -81,17 +92,19 @@ function articleMapper(
         body: null,
       },
     ],
-    category: sectionName
-      ? {
+    category:
+      fetchCategories && sectionName
+        ? {
+            id: null,
+            name: sectionName,
+          }
+        : null,
+    labels: fetchLabels
+      ? label_names?.map((label) => ({
           id: null,
-          name: sectionName,
-        }
+          name: String(label),
+        })) || null
       : null,
-    labels:
-      label_names?.map((label) => ({
-        id: null,
-        name: String(label),
-      })) || null,
   };
 
   return {

--- a/src/zendesk/zendesk-loader.spec.ts
+++ b/src/zendesk/zendesk-loader.spec.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Adapter } from '../adapter/adapter.js';
+import { Image } from '../model';
+import { ZendeskArticle } from './model/zendesk-article.js';
+import { ZendeskCategory } from './model/zendesk-category.js';
+import { ZendeskLabel } from './model/zendesk-label.js';
+import { ZendeskConfig } from './model/zendesk-config.js';
+import { ZendeskAdapter } from './zendesk-adapter.js';
+import { ZendeskLoader } from './zendesk-loader.js';
+import {
+  generateNormalizedCategory,
+  generateNormalizedLabel,
+  generateRawDocument,
+} from '../tests/utils/entity-generators';
+
+const mockGetAllArticles = jest.fn<() => Promise<ZendeskArticle[]>>();
+const mockGetAttachment =
+  jest.fn<(articleId: string | null, url: string) => Promise<Image | null>>();
+const mockGetAllCategories = jest.fn<() => Promise<ZendeskCategory[]>>();
+const mockGetAllLabels = jest.fn<() => Promise<ZendeskLabel[]>>();
+
+describe('ZendeskLoader', () => {
+  const LABEL = generateNormalizedLabel('', null, 'label-name');
+  const CATEGORY = generateNormalizedCategory('', null, 'category-name');
+  const DOCUMENT = generateRawDocument(
+    'article-body',
+    {
+      id: null,
+      name: 'category-name',
+    },
+    [
+      {
+        id: null,
+        name: 'label-name',
+      },
+    ],
+  );
+
+  let config: ZendeskConfig;
+  let adapter: ZendeskAdapter;
+  let loader: ZendeskLoader;
+
+  beforeEach(async () => {
+    config = {};
+    adapter = new ZendeskAdapter();
+    loader = new ZendeskLoader();
+
+    mockGetAllArticles.mockResolvedValueOnce([generateLoadedArticle()]);
+    mockGetAllCategories.mockResolvedValueOnce([generateLoadedCategory()]);
+    mockGetAllLabels.mockResolvedValueOnce([generateLoadedLabel()]);
+  });
+
+  describe('run', () => {
+    beforeEach(async () => {
+      await loader.initialize(config, {
+        sourceAdapter: adapter,
+        destinationAdapter: {} as Adapter,
+      });
+    });
+
+    it('should fetch articles, categories and labels', async () => {
+      await loader.run();
+
+      expect(mockGetAllArticles).toHaveBeenCalled();
+      expect(mockGetAllCategories).toHaveBeenCalled();
+      expect(mockGetAllLabels).toHaveBeenCalled();
+    });
+
+    it('should map entities', async () => {
+      const result = await loader.run();
+
+      expect(result).toEqual({
+        labels: [LABEL],
+        documents: [DOCUMENT],
+        categories: [CATEGORY],
+      });
+    });
+
+    describe('when categories excluded', () => {
+      beforeEach(async () => {
+        await loader.initialize(
+          { ...config, fetchCategories: 'false' },
+          {
+            sourceAdapter: adapter,
+            destinationAdapter: {} as Adapter,
+          },
+        );
+      });
+
+      it('should leave categories empty', async () => {
+        const result = await loader.run();
+
+        expect(result).toEqual({
+          labels: [LABEL],
+          documents: [
+            generateRawDocument('article-body', null, [
+              {
+                id: null,
+                name: 'label-name',
+              },
+            ]),
+          ],
+          categories: [],
+        });
+        expect(mockGetAllCategories).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when labels excluded', () => {
+      beforeEach(async () => {
+        await loader.initialize(
+          { ...config, fetchLabels: 'false' },
+          {
+            sourceAdapter: adapter,
+            destinationAdapter: {} as Adapter,
+          },
+        );
+      });
+
+      it('should leave labels empty', async () => {
+        const result = await loader.run();
+
+        expect(result).toEqual({
+          labels: [],
+          documents: [
+            generateRawDocument(
+              'article-body',
+              {
+                id: null,
+                name: 'category-name',
+              },
+              null,
+            ),
+          ],
+          categories: [CATEGORY],
+        });
+        expect(mockGetAllLabels).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when articles excluded', () => {
+      beforeEach(async () => {
+        await loader.initialize(
+          { ...config, fetchArticles: 'false' },
+          {
+            sourceAdapter: adapter,
+            destinationAdapter: {} as Adapter,
+          },
+        );
+      });
+
+      it('should leave documents empty', async () => {
+        const result = await loader.run();
+
+        expect(result).toEqual({
+          labels: [LABEL],
+          documents: [],
+          categories: [CATEGORY],
+        });
+        expect(mockGetAllArticles).not.toHaveBeenCalled();
+      });
+    });
+  });
+});
+
+jest.mock('./zendesk-adapter.js', () => {
+  return {
+    ZendeskAdapter: jest.fn().mockImplementation(() => {
+      return {
+        initialise: jest.fn<(config: ZendeskConfig) => Promise<void>>(),
+        getAllArticles: () => mockGetAllArticles(),
+        getAttachment: (articleId: string | null, url: string) =>
+          mockGetAttachment(articleId, url),
+        getAllCategories: () => mockGetAllCategories(),
+        getAllLabels: () => mockGetAllLabels(),
+      };
+    }),
+  };
+});
+
+function generateLoadedArticle(): ZendeskArticle {
+  return {
+    id: 'article-external-id',
+    title: 'article-title',
+    body: 'article-body',
+    draft: false,
+    section_id: 'category-external-id',
+    label_names: ['label-name'],
+  };
+}
+
+function generateLoadedCategory(): ZendeskCategory {
+  return {
+    id: 'category-external-id',
+    name: 'category-name',
+  };
+}
+
+function generateLoadedLabel(): ZendeskLabel {
+  return {
+    id: 'label-external-id',
+    name: 'label-name',
+  };
+}


### PR DESCRIPTION
Config got three new optional properties:

- FETCH_ARTICLES = 'true' | 'false'
- FETCH_CATEGORIES = 'true' | 'false'
- FETCH_LABELS = 'true' | 'false'

All three options have default 'true' value.
If any of them is set to false then Connector App will not fetch those entities from the 3rd party.