### PR TITLE
Delete entities only from the same source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knowledge-connector-app",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knowledge-connector-app",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "MIT",
       "dependencies": {
         "dotenv": "16.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-connector-app",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Knowledge Connector App",
   "module": "./dist/index.js",
   "main": "./dist/index.js",

--- a/src/aggregator/diff-aggregator.ts
+++ b/src/aggregator/diff-aggregator.ts
@@ -124,9 +124,9 @@ export class DiffAggregator implements Aggregator {
     });
 
     const prefix = this.config.externalIdPrefix;
-    result.deleted = unprocessedStoredItems.filter(
-      (item: T) =>
-        !!item?.externalId && (!prefix || item.externalId.startsWith(prefix)),
+    const sourceId = this.getSourceId();
+    result.deleted = unprocessedStoredItems.filter((item: T) =>
+      this.isFromSameSource(item, prefix, sourceId),
     );
 
     return result;
@@ -276,5 +276,43 @@ export class DiffAggregator implements Aggregator {
         currentItem.name === collectedItem.name &&
         currentItem.externalId !== collectedItem.externalId,
     );
+  }
+
+  private isFromSameSource(
+    item: ExternalIdentifiable,
+    prefix: string | undefined,
+    sourceId: string | null,
+  ): boolean {
+    if (sourceId) {
+      return this.isSourceIdMatch(item, sourceId);
+    }
+
+    if (prefix) {
+      return this.isExternalIdPrefixMatch(item, prefix);
+    }
+
+    return this.hasExternalId(item);
+  }
+
+  private isSourceIdMatch(
+    item: ExternalIdentifiable,
+    sourceId: string | null,
+  ): boolean {
+    return item.sourceId === sourceId;
+  }
+
+  private isExternalIdPrefixMatch(
+    item: ExternalIdentifiable,
+    prefix: string,
+  ): boolean {
+    return !!item?.externalId && item.externalId.startsWith(prefix);
+  }
+
+  private hasExternalId(item: ExternalIdentifiable): boolean {
+    return !!item?.externalId;
+  }
+
+  private getSourceId(): string | null {
+    return this.config.genesysSourceId || null;
   }
 }

--- a/src/model/external-identifiable.ts
+++ b/src/model/external-identifiable.ts
@@ -1,4 +1,5 @@
 export interface ExternalIdentifiable {
   id: string | null;
   externalId: string | null;
+  sourceId?: string | null;
 }

--- a/src/processor/image-processor.ts
+++ b/src/processor/image-processor.ts
@@ -196,7 +196,13 @@ export class ImageProcessor implements Processor {
         );
         return null;
       }
-      image = await this.downloadImage(url);
+
+      try {
+        image = await this.downloadImage(url);
+      } catch (error) {
+        getLogger().warn(`Unable to fetch image [${url}] directly`);
+        return null;
+      }
     }
 
     return image;

--- a/src/tests/utils/entity-generators.ts
+++ b/src/tests/utils/entity-generators.ts
@@ -9,11 +9,17 @@ export function generateNormalizedLabel(
   id: string | null = null,
   name: string = 'label-name' + suffix,
   externalId: string = 'label-external-id' + suffix,
+  sourceId: string | null = null,
 ): Label {
   return {
     id,
     name,
     externalId,
+    ...(sourceId
+      ? {
+          sourceId,
+        }
+      : {}),
     color: 'generated-value-color',
   };
 }
@@ -24,11 +30,17 @@ export function generateNormalizedCategory(
   name: string = 'category-name' + suffix,
   externalId: string = 'category-external-id' + suffix,
   parentCategory: CategoryReference | null = null,
+  sourceId: string | null = null,
 ): Category {
   return {
     id,
     name,
     externalId,
+    ...(sourceId
+      ? {
+          sourceId,
+        }
+      : {}),
     parentCategory,
   };
 }
@@ -40,10 +52,16 @@ export function generateNormalizedDocument(
   alternatives: DocumentAlternative[] | null = null,
   visible: boolean = true,
   externalId: string = 'article-external-id' + suffix,
+  sourceId: string | null = null,
 ): Document {
   return {
     id,
     externalId,
+    ...(sourceId
+      ? {
+          sourceId,
+        }
+      : {}),
     published: {
       title,
       visible,


### PR DESCRIPTION
When calculating the deleted entities, the following filters are applied
- if genesysSourceId is set in the config, then only entities with the same sourceId are scanned
- if externalIdPrefix is set in the config, then only entities with an external id starting with that prefix are scanned
- if non of the above configs are set, then only entities that have an external id are scanned