### PR TITLE
image url validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,15 @@ FETCH_CATEGORIES=
 FETCH_LABELS=
 ```
 
+#### Attachment (image) download allow-list
+
+```
+# Comma-separated list of domains names. If specified, images are downloaded only from these source domains (or their subdomains)
+# and uploaded to the destination. Images from other domains are not downloaded and their urls are left unchanged. If left empty,
+# images are downloaded from any domains. Example value: api-cdn.mypurecloud.com,api-cdn.mypurecloud.de
+ATTACHMENT_DOMAIN_ALLOW_LIST=
+```
+
 ### Installation
 
 1. Install dependencies `npm install`

--- a/src/processor/attachment-domain-not-allowed-error.spec.ts
+++ b/src/processor/attachment-domain-not-allowed-error.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from '@jest/globals';
+import { AttachmentDomainNotAllowedError } from './attachment-domain-not-allowed-error.js';
+
+describe('AttachmentDomainNotAllowedError', function () {
+  it('should work with instanceof operator', function () {
+    try {
+      throw new AttachmentDomainNotAllowedError(
+        'https://api-cdn.mypurecloud.com/image1.jpg',
+      );
+    } catch (error) {
+      expect(error instanceof AttachmentDomainNotAllowedError).toBe(true);
+      expect((<Error>error).message).toBe(
+        'Skipped downloading attachment, domain not allowed: https://api-cdn.mypurecloud.com/image1.jpg',
+      );
+    }
+  });
+});

--- a/src/processor/attachment-domain-not-allowed-error.ts
+++ b/src/processor/attachment-domain-not-allowed-error.ts
@@ -1,0 +1,5 @@
+export class AttachmentDomainNotAllowedError extends Error {
+  constructor(url: string) {
+    super('Skipped downloading attachment, domain not allowed: ' + url);
+  }
+}

--- a/src/processor/attachment-domain-validator-config.ts
+++ b/src/processor/attachment-domain-validator-config.ts
@@ -1,0 +1,5 @@
+import { Config } from '../config.js';
+
+export interface AttachmentDomainValidatorConfig extends Config {
+  attachmentDomainAllowList?: string;
+}

--- a/src/processor/attachment-domain-validator.spec.ts
+++ b/src/processor/attachment-domain-validator.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from '@jest/globals';
+import { AttachmentDomainValidator } from './attachment-domain-validator.js';
+
+describe('AttachmentDomainValidator', function () {
+  it('should not validate if the config value is missing', function () {
+    const validator = new AttachmentDomainValidator({});
+    expect(
+      validator.isDomainAllowed('https://api-cdn.mypurecloud.com/image.jpg'),
+    ).toBe(true);
+  });
+
+  it('should not validate if the config value is empty', function () {
+    const validator = new AttachmentDomainValidator({
+      attachmentDomainAllowList: '',
+    });
+    expect(
+      validator.isDomainAllowed('https://api-cdn.mypurecloud.com/image.jpg'),
+    ).toBe(true);
+  });
+
+  it('should return true if the domain of the url listed in the config, false otherwise', function () {
+    const validator = new AttachmentDomainValidator({
+      attachmentDomainAllowList: 'api-cdn.mypurecloud.com',
+    });
+    expect(
+      validator.isDomainAllowed('https://api-cdn.mypurecloud.com/image.jpg'),
+    ).toBe(true);
+    expect(
+      validator.isDomainAllowed('https://api-cdn.usw2.pure.cloud/image.jpg'),
+    ).toBe(false);
+  });
+
+  it('should accept subdomains, but not different domains', function () {
+    const validator = new AttachmentDomainValidator({
+      attachmentDomainAllowList: 'api-cdn.mypurecloud.com',
+    });
+    expect(validator.isDomainAllowed('https://api-cdn.mypurecloud.com/image.jpg')).toBe(
+      true,
+    );
+    expect(
+      validator.isDomainAllowed('https://subdomain.api-cdn.mypurecloud.com/image.jpg'),
+    ).toBe(true);
+    expect(
+      validator.isDomainAllowed('https://other.mypurecloud.com/image.jpg'),
+    ).toBe(false);
+    expect(
+      validator.isDomainAllowed('https://other-api-cdn.mypurecloud.com/image.jpg'),
+    ).toBe(false);
+  });
+
+  it('should split and trim config values', function () {
+    const validator = new AttachmentDomainValidator({
+      attachmentDomainAllowList:
+        'api-cdn.mypurecloud.com, api-cdn.usw2.pure.cloud, api-cdn.sae1.pure.cloud ',
+    });
+    expect(
+      validator.isDomainAllowed('https://api-cdn.mypurecloud.com/image.jpg'),
+    ).toBe(true);
+    expect(
+      validator.isDomainAllowed('https://api-cdn.usw2.pure.cloud/image.jpg'),
+    ).toBe(true);
+    expect(
+      validator.isDomainAllowed('https://api-cdn.sae1.pure.cloud/image.jpg'),
+    ).toBe(true);
+    expect(
+      validator.isDomainAllowed('https://api-cdn.mypurecloud.de/image.jpg'),
+    ).toBe(false);
+  });
+});

--- a/src/processor/attachment-domain-validator.ts
+++ b/src/processor/attachment-domain-validator.ts
@@ -1,0 +1,30 @@
+import { AttachmentDomainValidatorConfig } from './attachment-domain-validator-config.js';
+
+export class AttachmentDomainValidator {
+  private attachmentDomainAllowList: string[];
+  private enabled: boolean;
+
+  constructor(config: AttachmentDomainValidatorConfig) {
+    this.attachmentDomainAllowList = config.attachmentDomainAllowList
+      ? config.attachmentDomainAllowList
+          .split(',')
+          .map((domain) => domain.trim())
+      : [];
+    this.enabled = this.attachmentDomainAllowList.length > 0;
+  }
+
+  public isDomainAllowed(url: string): boolean {
+    if (!this.enabled) {
+      return true;
+    }
+    try {
+      const urlObject = new URL(url);
+      return this.attachmentDomainAllowList.some(
+        (domain) =>
+          urlObject.host === domain || urlObject.host.endsWith('.' + domain),
+      );
+    } catch (error) {
+      return false;
+    }
+  }
+}

--- a/src/processor/image-processor.spec.ts
+++ b/src/processor/image-processor.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '../tests/utils/entity-generators.js';
 import { Image } from '../model/image.js';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { AttachmentDomainNotAllowedError } from './attachment-domain-not-allowed-error.js';
 
 jest.mock('../utils/web-client.js');
 jest.mock('../genesys/genesys-destination-adapter.js');
@@ -86,6 +87,82 @@ describe('ImageProcessor', () => {
         result.documents[0].published?.variations[0].body?.blocks[1].table
           ?.rows[1].cells[0].blocks[0].image?.url,
       ).toBe('https://api.mypurecloud.com/image');
+    });
+
+    it('should not replace image block urls if adapter.getAttachment throws domain not allowed error', async () => {
+      mockGetAttachment.mockRejectedValue(
+        new AttachmentDomainNotAllowedError('https://attachment-url'),
+      );
+
+      const result = await imageProcessor.run({
+        categories: [],
+        labels: [],
+        documents: [generateNormalizedDocument('1')],
+      });
+
+      expect(
+        result.documents[0].published?.variations[0].body?.blocks[0].image?.url,
+      ).toBe('https://document-image.url');
+    });
+
+    it('should propagate other adapter.getAttachment errors', async () => {
+      mockGetAttachment.mockRejectedValue(
+        new Error('something unexpected happened'),
+      );
+
+      expect(
+        imageProcessor.run({
+          categories: [],
+          labels: [],
+          documents: [generateNormalizedDocument('1')],
+        }),
+      ).rejects.toThrow('something unexpected happened');
+    });
+
+    it('should download images with relative urls from allowed domains', async () => {
+      const config = {
+        relativeImageBaseUrl: 'https://api-cdn.usw2.pure.cloud',
+        attachmentDomainAllowList: 'api-cdn.usw2.pure.cloud',
+      };
+      imageProcessor = new ImageProcessor();
+      await imageProcessor.initialize(config, adapters);
+      mockGetAttachment.mockResolvedValue(null);
+      const documents = [generateNormalizedDocument('1')];
+      documents[0].published!.variations[0].body!.blocks[0].image!.url =
+        'relative-image.jpg';
+
+      const result = await imageProcessor.run({
+        categories: [],
+        labels: [],
+        documents,
+      });
+
+      expect(
+        result.documents[0].published?.variations[0].body?.blocks[0].image?.url,
+      ).toBe('https://api.mypurecloud.com/image');
+    });
+
+    it('should not download images with relative urls from not allowed domains', async () => {
+      const config = {
+        relativeImageBaseUrl: 'https://api-cdn.usw2.pure.cloud',
+        attachmentDomainAllowList: 'api-cdn.mypurecloud.com',
+      };
+      imageProcessor = new ImageProcessor();
+      await imageProcessor.initialize(config, adapters);
+      mockGetAttachment.mockResolvedValue(null);
+      const documents = [generateNormalizedDocument('1')];
+      documents[0].published!.variations[0].body!.blocks[0].image!.url =
+        'relative-image.jpg';
+
+      const result = await imageProcessor.run({
+        categories: [],
+        labels: [],
+        documents,
+      });
+
+      expect(
+        result.documents[0].published?.variations[0].body?.blocks[0].image?.url,
+      ).toBe('relative-image.jpg');
     });
   });
 });

--- a/src/servicenow/servicenow-adapter.ts
+++ b/src/servicenow/servicenow-adapter.ts
@@ -32,7 +32,8 @@ export class ServiceNowAdapter
     articleId: string | null,
     url: string,
   ): Promise<Image | null> {
-    const attachmentIdMatch = url.match(/sys_id=([^&]+)/);
+    // sys_id=e78fb8af47474650376bb52f316d4313 or sys_id&#61;e78fb8af47474650376bb52f316d4313
+    const attachmentIdMatch = url.match(/sys_id(?:=|&#61;)([^&]+)/);
     if (!attachmentIdMatch || !articleId) {
       return null;
     }


### PR DESCRIPTION
- Provide a domain allow-list in the configuration and only download attachment images from those source domains. Other image urls are left unchanged and not downloaded from the source or uploaded to the destination.
- parse url-encoded sys_id query params in ServiceNow attachment urls