### PR TITLE
Updating diff checker to properly handle undefined properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-connector-app",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Knowledge Connector App",
   "module": "./dist/index.js",
   "main": "./dist/index.js",

--- a/src/aggregator/diff-aggregator.ts
+++ b/src/aggregator/diff-aggregator.ts
@@ -119,7 +119,7 @@ export class DiffAggregator implements Aggregator {
 
         if (
           !_.isEqualWith(collectedItem, normalizedStoredItem, (c, s) =>
-            this.isEqualCustomizer(c, s),
+            this.isEqualCustomizerFiltered(c, s),
           )
         ) {
           result.updated.push(collectedItem);
@@ -244,6 +244,12 @@ export class DiffAggregator implements Aggregator {
     };
   }
 
+  private isEqualCustomizerFiltered(c: any, s: any): boolean | undefined {
+    const filteredC = this.filterUndefinedDeep(c);
+    const filteredS = this.filterUndefinedDeep(s);
+    return this.isEqualCustomizer(filteredC, filteredS);
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private isEqualCustomizer(c: any, s: any): boolean | undefined {
     if (_.isString(c) && c === GeneratedValue.COLOR) {
@@ -254,11 +260,7 @@ export class DiffAggregator implements Aggregator {
       return _.isEqual(c.sort(), s.sort());
     }
 
-    if (_.isPlainObject(c) && _.isPlainObject(s)) {
-      const filteredC = this.filterUndefinedDeep(c);
-      const filteredS = this.filterUndefinedDeep(s);
-      return _.isEqual(filteredC, filteredS);
-    }
+    return _.isEqual(c, s);
   }
 
   private filterUndefinedDeep(obj: any): any {

--- a/src/aggregator/diff-aggregator.ts
+++ b/src/aggregator/diff-aggregator.ts
@@ -117,9 +117,11 @@ export class DiffAggregator implements Aggregator {
 
         this.copyProtectedContent(normalizedStoredItem, collectedItem);
 
+        const filteredC = this.filterUndefinedDeep(collectedItem);
+        const filteredS = this.filterUndefinedDeep(normalizedStoredItem);
         if (
-          !_.isEqualWith(collectedItem, normalizedStoredItem, (c, s) =>
-            this.isEqualCustomizerFiltered(c, s),
+          !_.isEqualWith(filteredC, filteredS, (c, s) =>
+            this.isEqualCustomizer(c, s),
           )
         ) {
           result.updated.push(collectedItem);
@@ -242,12 +244,6 @@ export class DiffAggregator implements Aggregator {
       id: null,
       name,
     };
-  }
-
-  private isEqualCustomizerFiltered(c: any, s: any): boolean | undefined {
-    const filteredC = this.filterUndefinedDeep(c);
-    const filteredS = this.filterUndefinedDeep(s);
-    return this.isEqualCustomizer(filteredC, filteredS);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/aggregator/diff-aggregator.ts
+++ b/src/aggregator/diff-aggregator.ts
@@ -178,7 +178,7 @@ export class DiffAggregator implements Aggregator {
     } = documentVersion;
     return {
       title: title ? title.trim() : title,
-      externalUrl,
+      externalUrl: externalUrl ?? null,
       alternatives: alternatives ?? null,
       visible,
       category: category ? this.normalizeCategoryReference(category) : null,
@@ -248,9 +248,30 @@ export class DiffAggregator implements Aggregator {
   private isEqualCustomizer(c: any, s: any): boolean | undefined {
     if (_.isString(c) && c === GeneratedValue.COLOR) {
       return true; // always accept stored value if collected value is generated
-    } else if (_.isArray(c) && _.isArray(s) && c.length && _.isString(c[0])) {
+    }
+
+    if (_.isArray(c) && _.isArray(s) && c.length && _.isString(c[0])) {
       return _.isEqual(c.sort(), s.sort());
     }
+
+    if (_.isPlainObject(c) && _.isPlainObject(s)) {
+      const filteredC = this.filterUndefinedDeep(c);
+      const filteredS = this.filterUndefinedDeep(s);
+      return _.isEqual(filteredC, filteredS);
+    }
+  }
+
+  private filterUndefinedDeep(obj: any): any {
+    if (_.isArray(obj)) {
+      return obj.map(this.filterUndefinedDeep.bind(this));
+    } else if (_.isObject(obj) && !_.isDate(obj)) {
+      return _.transform(obj, (result, value, key) => {
+        if (!_.isUndefined(value)) {
+          result[key] = this.filterUndefinedDeep(value);
+        }
+      });
+    }
+    return obj;
   }
 
   private copyProtectedContent<T extends object>(

--- a/src/aggregator/diff-aggregator.ts
+++ b/src/aggregator/diff-aggregator.ts
@@ -255,10 +255,9 @@ export class DiffAggregator implements Aggregator {
     if (_.isArray(c) && _.isArray(s) && c.length && _.isString(c[0])) {
       return _.isEqual(c.sort(), s.sort());
     }
-
-    return _.isEqual(c, s);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private filterUndefinedDeep(obj: any): any {
     if (_.isArray(obj)) {
       return obj.map(this.filterUndefinedDeep.bind(this));

--- a/src/salesforce/content-mapper.ts
+++ b/src/salesforce/content-mapper.ts
@@ -20,14 +20,6 @@ export function contentMapper(
   fetchCategories: boolean,
   buildExternalUrls: boolean,
 ): ExternalContent {
-  const labelsMapping = buildIdAndNameMapping(categoryGroups);
-  const contentFields = (
-    config.salesforceArticleContentFields?.split(',') || []
-  )
-    .map((f) => f.trim())
-    .filter((f) => f.length > 0);
-  const baseUrl = config.salesforceLightningBaseUrl;
-
   validateNonNull(
     config.salesforceLanguageCode,
     'Missing SALESFORCE_LANGUAGE_CODE from config',
@@ -41,6 +33,14 @@ export function contentMapper(
   const lightningLanguageCode = sfLanguageCode
     .replace('-', '_')
     .replace(/_([a-z]{2})$/, (_, p1) => `_${p1.toUpperCase()}`);
+
+  const labelsMapping = buildIdAndNameMapping(categoryGroups);
+  const contentFields = (
+    config.salesforceArticleContentFields?.split(',') || []
+  )
+    .map((f) => f.trim())
+    .filter((f) => f.length > 0);
+  const baseUrl = config.salesforceLightningBaseUrl;
 
   return {
     labels: Array.from(labelsMapping, ([key, value]) => ({

--- a/src/salesforce/content-mapper.ts
+++ b/src/salesforce/content-mapper.ts
@@ -9,7 +9,7 @@ import { LabelReference } from '../model/label-reference.js';
 import { ExternalLink } from '../model/external-link.js';
 import { SalesforceConfig } from './model/salesforce-config.js';
 import { LANGUAGE_MAPPING } from './salesforce-language-mapping.js';
-import { validateNonNull } from '../utils/validate-non-null';
+import { validateNonNull } from '../utils/validate-non-null.js';
 
 const EXCLUDED_FIELD_TYPES = ['DATE_TIME', 'LOOKUP', 'CHECKBOX'];
 


### PR DESCRIPTION
The old version of isEqualCustomizer handled undefined properties wrong. An unset (and thus undefined) property would not match to a set, but also undefined property and thus resulting an update. With the updated isEqualCustomizer undefined properties are ignored during the equal checking, so they won't cause unwanted updates