### PR TITLE
Fix externalUrl preparation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knowledge-connector-app",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knowledge-connector-app",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "dotenv": "16.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-connector-app",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Knowledge Connector App",
   "module": "./dist/index.js",
   "main": "./dist/index.js",

--- a/src/aggregator/diff-aggregator.ts
+++ b/src/aggregator/diff-aggregator.ts
@@ -156,11 +156,12 @@ export class DiffAggregator implements Aggregator {
   }
 
   private normalizeDocument(document: Document): Document {
-    const { externalId, published, draft } = document;
+    const { externalId, externalUrl, published, draft } = document;
 
     return {
       id: null,
       externalId: externalId || null,
+      externalUrl: externalUrl || null,
       published: published ? this.normalizeDocumentVersion(published) : null,
       draft: draft ? this.normalizeDocumentVersion(draft) : null,
     };
@@ -169,18 +170,10 @@ export class DiffAggregator implements Aggregator {
   private normalizeDocumentVersion(
     documentVersion: DocumentVersion,
   ): DocumentVersion {
-    const {
-      title,
-      externalUrl,
-      alternatives,
-      visible,
-      category,
-      labels,
-      variations,
-    } = documentVersion;
+    const { title, alternatives, visible, category, labels, variations } =
+      documentVersion;
     return {
       title: title ? title.trim() : title,
-      externalUrl: externalUrl ?? null,
       alternatives: alternatives ?? null,
       visible,
       category: category ? this.normalizeCategoryReference(category) : null,

--- a/src/genesys/content-mapper.ts
+++ b/src/genesys/content-mapper.ts
@@ -40,11 +40,12 @@ function labelMapper(label: Label): Label {
 }
 
 function documentMapper(article: Document): Document {
-  const { id, published, draft } = article;
+  const { id, externalUrl, published, draft } = article;
 
   return {
     id: null,
     externalId: String(id),
+    externalUrl,
     published,
     draft,
   };

--- a/src/model/sync-export-model.ts
+++ b/src/model/sync-export-model.ts
@@ -36,13 +36,13 @@ export interface ExportModel {
 }
 
 export interface Document extends ExternalIdentifiable {
+  externalUrl: string | null;
   published: DocumentVersion | null;
   draft: DocumentVersion | null;
 }
 
 export interface DocumentVersion {
   title: string;
-  externalUrl: string | null;
   alternatives: DocumentAlternative[] | null;
   visible: boolean;
   category: CategoryReference | null;

--- a/src/processor/url-transformer/url-transformer.spec.ts
+++ b/src/processor/url-transformer/url-transformer.spec.ts
@@ -129,11 +129,11 @@ describe('UrlTransformer', () => {
     return {
       id: '',
       externalId: 'external-id',
+      externalUrl: null,
       published: {
         title: 'document-title',
         visible: true,
         alternatives: null,
-        externalUrl: null,
         variations: [
           {
             body: {

--- a/src/salesforce/content-mapper.spec.ts
+++ b/src/salesforce/content-mapper.spec.ts
@@ -48,7 +48,7 @@ describe('contentMapper', () => {
         true,
       );
 
-      expect(result.documents[0].published?.externalUrl).toBe(
+      expect(result.documents[0].externalUrl).toBe(
         'https://test.lightning.force.com/articles/en_US/Knowledge/testUrl',
       );
     });

--- a/src/salesforce/content-mapper.ts
+++ b/src/salesforce/content-mapper.ts
@@ -131,9 +131,6 @@ function articleMapper(
     visible: true,
     alternatives: null,
     title,
-    externalUrl: buildExternalUrls
-      ? buildExternalUrl(baseUrl, language, article.urlName)
-      : null,
     variations: [
       {
         rawHtml: buildArticleBody(layoutItems, salesforceArticleContentFields),
@@ -147,6 +144,9 @@ function articleMapper(
   return {
     id: null,
     externalId: String(id),
+    externalUrl: buildExternalUrls
+      ? buildExternalUrl(baseUrl, language, article.urlName)
+      : null,
     published: documentVersion,
     draft: null,
   };

--- a/src/servicenow/content-mapper.spec.ts
+++ b/src/servicenow/content-mapper.spec.ts
@@ -8,7 +8,7 @@ describe('contentMapper', () => {
         servicenowBaseUrl: 'https://test.service-now.com',
       });
 
-      expect(result.documents[0].published?.externalUrl).toBe(
+      expect(result.documents[0].externalUrl).toBe(
         'https://test.service-now.com/kb_view.do?sysparm_article=KB0012437',
       );
     });

--- a/src/servicenow/content-mapper.ts
+++ b/src/servicenow/content-mapper.ts
@@ -55,9 +55,6 @@ function articleMapper(
 
   const documentVersion: DocumentVersion = {
     visible: true,
-    externalUrl: buildExternalUrls
-      ? buildExternalUrl(baseUrl, article.number)
-      : null,
     alternatives: null,
     title,
     variations: [
@@ -73,6 +70,9 @@ function articleMapper(
   return {
     id: null,
     externalId: String(id),
+    externalUrl: buildExternalUrls
+      ? buildExternalUrl(baseUrl, article.number)
+      : null,
     published: state === 'published' ? documentVersion : null,
     draft: state !== 'published' ? documentVersion : null,
   };

--- a/src/tests/utils/entity-generators.ts
+++ b/src/tests/utils/entity-generators.ts
@@ -57,6 +57,7 @@ export function generateNormalizedDocument(
   return {
     id,
     externalId,
+    externalUrl: null,
     ...(sourceId
       ? {
           sourceId,
@@ -64,7 +65,6 @@ export function generateNormalizedDocument(
       : {}),
     published: {
       title,
-      externalUrl: null,
       visible,
       alternatives,
       variations: [
@@ -101,6 +101,7 @@ export function generateNormalizedDocumentWithInternalDocumentLinks(
   return {
     id,
     externalId,
+    externalUrl: null,
     ...(sourceId
       ? {
           sourceId,
@@ -108,7 +109,6 @@ export function generateNormalizedDocumentWithInternalDocumentLinks(
       : {}),
     published: {
       title,
-      externalUrl: null,
       visible,
       alternatives,
       variations: [
@@ -153,9 +153,9 @@ export function generateDocumentWithTable(suffix: string): Document {
   return {
     id: '',
     externalId: 'documents-' + suffix,
+    externalUrl: null,
     published: {
       title: 'document-title' + suffix,
-      externalUrl: null,
       visible: true,
       alternatives: null,
       variations: [
@@ -257,9 +257,9 @@ export function generateDocumentWithLinkedDocuments(suffix: string): Document {
   return {
     id: '',
     externalId: 'documents-' + suffix,
+    externalUrl: null,
     published: {
       title: 'document-title' + suffix,
-      externalUrl: null,
       visible: true,
       alternatives: null,
       variations: [
@@ -395,9 +395,9 @@ export function generateRawDocument(
   return {
     id: null,
     externalId: 'article-external-id',
+    externalUrl: null,
     published: {
       title: 'article-title',
-      externalUrl: null,
       visible: true,
       alternatives: null,
       variations: [

--- a/src/zendesk/content-mapper.ts
+++ b/src/zendesk/content-mapper.ts
@@ -88,7 +88,6 @@ function articleMapper(
     visible: true,
     alternatives: null,
     title,
-    externalUrl: null,
     variations: [
       {
         rawHtml: body,
@@ -113,6 +112,7 @@ function articleMapper(
   return {
     id: null,
     externalId: String(id),
+    externalUrl: null,
     published: !draft ? documentVersion : null,
     draft: draft ? documentVersion : null,
   };


### PR DESCRIPTION
The property externalUrl is moved to Document level instead of DocumentVersion level.