### PR TITLE
fix trailing slash causing double slashes in generated urls issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knowledge-connector-app",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knowledge-connector-app",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "license": "MIT",
       "dependencies": {
         "dotenv": "16.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-connector-app",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Knowledge Connector App",
   "module": "./dist/index.js",
   "main": "./dist/index.js",

--- a/src/genesys/genesys-destination-api.ts
+++ b/src/genesys/genesys-destination-api.ts
@@ -14,6 +14,7 @@ import { BulkDeleteResponse } from '../model/bulk-delete-response.js';
 import { GenesysApi } from './genesys-api.js';
 import { GenesysDestinationConfig } from './model/genesys-destination-config.js';
 import { fetch } from '../utils/web-client.js';
+import { removeTrailingSlash } from '../utils/remove-trailing-slash.js';
 
 export class GenesysDestinationApi extends GenesysApi {
   protected config: GenesysDestinationConfig = {};
@@ -28,7 +29,7 @@ export class GenesysDestinationApi extends GenesysApi {
       this.config.genesysLoginUrl,
       'Missing GENESYS_LOGIN_URL from config',
     );
-    return this.config.genesysLoginUrl!;
+    return removeTrailingSlash(this.config.genesysLoginUrl!);
   }
 
   protected getBaseUrl(): string {
@@ -36,7 +37,7 @@ export class GenesysDestinationApi extends GenesysApi {
       this.config.genesysBaseUrl,
       'Missing GENESYS_BASE_URL from config',
     );
-    return this.config.genesysBaseUrl!;
+    return removeTrailingSlash(this.config.genesysBaseUrl!);
   }
 
   protected getClientId(): string {

--- a/src/genesys/genesys-source-api.ts
+++ b/src/genesys/genesys-source-api.ts
@@ -1,6 +1,7 @@
 import { validateNonNull } from '../utils/validate-non-null.js';
 import { GenesysApi } from './genesys-api.js';
 import { GenesysSourceConfig } from './model/genesys-source-config.js';
+import { removeTrailingSlash } from '../utils/remove-trailing-slash.js';
 
 export class GenesysSourceApi extends GenesysApi {
   private config: GenesysSourceConfig = {};
@@ -15,7 +16,7 @@ export class GenesysSourceApi extends GenesysApi {
       this.config.genesysSourceLoginUrl,
       'Missing GENESYS_SOURCE_LOGIN_URL from config',
     );
-    return this.config.genesysSourceLoginUrl!;
+    return removeTrailingSlash(this.config.genesysSourceLoginUrl!);
   }
 
   protected getBaseUrl(): string {
@@ -23,7 +24,7 @@ export class GenesysSourceApi extends GenesysApi {
       this.config.genesysSourceBaseUrl,
       'Missing GENESYS_SOURCE_BASE_URL from config',
     );
-    return this.config.genesysSourceBaseUrl!;
+    return removeTrailingSlash(this.config.genesysSourceBaseUrl!);
   }
 
   protected getClientId(): string {

--- a/src/salesforce/content-mapper.ts
+++ b/src/salesforce/content-mapper.ts
@@ -10,6 +10,7 @@ import { ExternalLink } from '../model/external-link.js';
 import { SalesforceConfig } from './model/salesforce-config.js';
 import { LANGUAGE_MAPPING } from './salesforce-language-mapping.js';
 import { validateNonNull } from '../utils/validate-non-null.js';
+import { removeTrailingSlash } from '../utils/remove-trailing-slash.js';
 
 const EXCLUDED_FIELD_TYPES = ['DATE_TIME', 'LOOKUP', 'CHECKBOX'];
 
@@ -40,7 +41,7 @@ export function contentMapper(
   )
     .map((f) => f.trim())
     .filter((f) => f.length > 0);
-  const baseUrl = config.salesforceLightningBaseUrl;
+  const baseUrl = removeTrailingSlash(config.salesforceLightningBaseUrl || '');
 
   return {
     labels: Array.from(labelsMapping, ([key, value]) => ({

--- a/src/salesforce/salesforce-api.ts
+++ b/src/salesforce/salesforce-api.ts
@@ -13,6 +13,7 @@ import { SalesforceAccessTokenResponse } from './model/salesforce-access-token-r
 import { LANGUAGE_MAPPING } from './salesforce-language-mapping.js';
 import { InvalidCredentialsError } from '../adapter/errors/invalid-credentials-error.js';
 import { ApiError } from '../adapter/errors/api-error.js';
+import { removeTrailingSlash } from '../utils/remove-trailing-slash.js';
 
 export class SalesforceApi {
   private config: SalesforceConfig = {};
@@ -124,6 +125,7 @@ export class SalesforceApi {
 
     const loginUrl =
       this.config.salesforceLoginUrl || this.config.salesforceBaseUrl;
+    const processedLoginUrl = removeTrailingSlash(loginUrl || '');
 
     const bodyParams = new URLSearchParams();
     bodyParams.append('grant_type', 'password');
@@ -132,7 +134,7 @@ export class SalesforceApi {
     bodyParams.append('username', this.config.salesforceUsername!);
     bodyParams.append('password', this.config.salesforcePassword!);
 
-    const response = await fetch(`${loginUrl}/services/oauth2/token`, {
+    const response = await fetch(`${processedLoginUrl}/services/oauth2/token`, {
       method: 'POST',
       body: bodyParams,
       headers: {

--- a/src/servicenow/servicenow-api.ts
+++ b/src/servicenow/servicenow-api.ts
@@ -4,14 +4,17 @@ import { fetch, Response } from '../utils/web-client.js';
 import { ServiceNowResponse } from './model/servicenow-response.js';
 import { ServiceNowArticleAttachment } from './model/servicenow-article-attachment.js';
 import { ApiError } from '../adapter/errors/api-error.js';
+import { removeTrailingSlash } from '../utils/remove-trailing-slash.js';
 
 export class ServiceNowApi {
   private config: ServiceNowConfig = {};
   private limit: number = 0;
+  private baseUrl: string = '';
 
   public async initialize(config: ServiceNowConfig): Promise<void> {
     this.config = config;
     this.limit = this.config.limit ? parseInt(this.config.limit, 10) : 50;
+    this.baseUrl = removeTrailingSlash(this.config.servicenowBaseUrl || '');
   }
 
   public async fetchAllArticles(): Promise<ServiceNowArticle[]> {
@@ -21,7 +24,7 @@ export class ServiceNowApi {
   }
 
   private async getPage<T>(endpoint: string): Promise<ServiceNowArticle[]> {
-    const url = this.buildUrl(`${this.config.servicenowBaseUrl}${endpoint}`);
+    const url = this.buildUrl(`${this.baseUrl}${endpoint}`);
     const response = await fetch(url, {
       headers: this.buildHeaders(),
     });
@@ -43,7 +46,7 @@ export class ServiceNowApi {
   public async fetchAttachmentInfo(
     attachmentId: string,
   ): Promise<ServiceNowArticleAttachment> {
-    const url = `${this.config.servicenowBaseUrl}/api/now/attachment/${attachmentId}`;
+    const url = `${this.baseUrl}/api/now/attachment/${attachmentId}`;
     const response = await fetch(url, {
       headers: this.buildHeaders(),
     });

--- a/src/utils/remove-trailing-slash.ts
+++ b/src/utils/remove-trailing-slash.ts
@@ -1,0 +1,10 @@
+/**
+ * Removes trailing slash from the end of the url if it is present
+ * @param url
+ */
+export function removeTrailingSlash(url: string): string {
+  if (url.endsWith('/') && url.length > 1) {
+    return url.slice(0, -1);
+  }
+  return url;
+}

--- a/src/zendesk/zendesk-api.ts
+++ b/src/zendesk/zendesk-api.ts
@@ -7,12 +7,15 @@ import { ZendeskArticle } from './model/zendesk-article.js';
 import { ZendeskLabel } from './model/zendesk-label.js';
 import { fetch, HeadersInit, Response } from '../utils/web-client.js';
 import { ApiError } from '../adapter/errors/api-error.js';
+import { removeTrailingSlash } from '../utils/remove-trailing-slash.js';
 
 export class ZendeskApi {
   private config: ZendeskConfig = {};
+  private baseUrl: string = '';
 
   public initialize(config: ZendeskConfig): Promise<void> {
     this.config = config;
+    this.baseUrl = removeTrailingSlash(config.zendeskBaseUrl || '');
     return Promise.resolve(undefined);
   }
 
@@ -71,7 +74,7 @@ export class ZendeskApi {
   }
 
   private get<T>(endpoint: string, property: ZendeskEntityTypes): Promise<T[]> {
-    return this.getPage(`${this.config.zendeskBaseUrl}${endpoint}`, property);
+    return this.getPage(`${this.baseUrl}${endpoint}`, property);
   }
 
   private async getPage<T>(


### PR DESCRIPTION
We had an issue where trailing slash in urls in the config caused bad urls being generated due to double slashing.
This change fixes that issue by removing the trailing slash from the end of the urls