### PR TITLE
Fix SF category based article filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knowledge-connector-app",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knowledge-connector-app",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "license": "MIT",
       "dependencies": {
         "dotenv": "16.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-connector-app",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Knowledge Connector App",
   "module": "./dist/index.js",
   "main": "./dist/index.js",

--- a/src/salesforce/salesforce-api.ts
+++ b/src/salesforce/salesforce-api.ts
@@ -241,6 +241,7 @@ export class SalesforceApi {
     }
     if (this.config.salesforceCategories) {
       filters.push(`categories=${this.config.salesforceCategories}`);
+      filters.push('queryMethod=AT');
     }
 
     return filters.join('&');


### PR DESCRIPTION
SF article listing by categories was using the default query method (ABOVE_OR_BELOW). It included the parent/grandparent's articles, too. BELOW would only include articles under the selected article which is the desired outcome in our use-case.

https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_knowledge_support_artlist.htm 

with the additional queryMethod=BELOW query param we can ensure that articles with only the selected category or its children categories will be returned