### PR TITLE
Duplicate filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change log
 
+## 0.9.8 (2025-04-03)
+
+### Fixes:
+
+1. Updated pagination handling: next page results are now added to unprocessedItems collection
+
+### Changes:
+
+1. Added duplicate filter to prevent syncing multiple articles with the same external ID
+
 ## 0.9.7 (2025-03-20)
 
 ### Fixes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knowledge-connector-app",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knowledge-connector-app",
-      "version": "0.9.7",
+      "version": "0.9.8",
       "license": "MIT",
       "dependencies": {
         "dotenv": "16.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-connector-app",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Knowledge Connector App",
   "module": "./dist/index.js",
   "main": "./dist/index.js",

--- a/src/filter/duplicate-filter.ts
+++ b/src/filter/duplicate-filter.ts
@@ -1,0 +1,81 @@
+import { Filter } from './filter.js';
+import { PipeContext } from '../pipe/pipe-context.js';
+import { AdapterPair } from '../adapter/adapter-pair.js';
+import { Adapter } from '../adapter/adapter.js';
+import { DestinationAdapter } from '../adapter/destination-adapter.js';
+import { Category, Document, Label } from '../model';
+import { ModificationDateFilterConfig } from './modification-date-filter-config.js';
+import { getLogger } from '../utils/logger.js';
+
+export class DuplicateFilter implements Filter {
+  private context?: PipeContext;
+  private externalIdPrefix?: string;
+
+  public async initialize(
+    config: ModificationDateFilterConfig,
+    _adapters: AdapterPair<Adapter, DestinationAdapter>,
+    context: PipeContext,
+  ): Promise<void> {
+    this.context = context;
+    this.externalIdPrefix = config.externalIdPrefix ?? undefined;
+  }
+
+  public async runOnCategory(_content: Category): Promise<boolean> {
+    return true;
+  }
+
+  public async runOnLabel(_content: Label): Promise<boolean> {
+    return true;
+  }
+
+  public async runOnDocument(content: Document): Promise<boolean> {
+    const prefixedExternalId = this.getPrefixedExternalId(content.externalId);
+
+    const duplicate =
+      (this.context!.pipe.processedItems.documents || []).find(
+        (item) =>
+          item.externalId === prefixedExternalId ||
+          item.externalId === content.externalId,
+      ) ||
+      (this.context!.pipe.unprocessedItems.documents || []).find(
+        (item) =>
+          item.externalId === prefixedExternalId ||
+          item.externalId === content.externalId,
+      );
+
+    if (duplicate) {
+      const {
+        externalUrl: currentExternalUrl,
+        externalIdAlternatives: currentExternalIdAlternatives,
+        externalVersionId: currentExternalVersionId,
+      } = content;
+      const {
+        externalUrl: originalExternalUrl,
+        externalIdAlternatives: originalExternalIdAlternatives,
+        externalVersionId: originalExternalVersionId,
+      } = duplicate;
+
+      getLogger().warn(
+        `Duplicate document found with ID ${content.externalId}: ${JSON.stringify(
+          {
+            currentExternalUrl,
+            originalExternalUrl,
+            currentExternalIdAlternatives,
+            originalExternalIdAlternatives,
+            currentExternalVersionId,
+            originalExternalVersionId,
+          },
+        )}`,
+      );
+      return false;
+    }
+
+    return true;
+  }
+
+  private getPrefixedExternalId(externalId: string | null): string | null {
+    return this.externalIdPrefix
+      ? this.externalIdPrefix + externalId
+      : externalId;
+  }
+}

--- a/src/genesys/configurer.ts
+++ b/src/genesys/configurer.ts
@@ -18,7 +18,7 @@ export const configurer: Configurer = (pipe: Pipe) => {
       new PrefixExternalId(),
       new DocumentLinkProcessor(),
     )
-    .filter(new ModificationDateFilter())
+    .filters(new ModificationDateFilter())
     .aggregator(new DiffAggregator())
     .uploaders(new DiffUploader());
 };

--- a/src/pipe/pipe.spec.ts
+++ b/src/pipe/pipe.spec.ts
@@ -60,7 +60,7 @@ describe('Pipe', () => {
       .adapters(adapterPair)
       .loaders(loaderMock)
       .processors(processorMock)
-      .filter(filterMock)
+      .filters(filterMock)
       .aggregator(aggregatorMock)
       .uploaders(uploaderMock)
       .start({});
@@ -93,7 +93,7 @@ describe('Pipe', () => {
       .adapters(adapterPair)
       .loaders(loaderMock)
       .processors(processorMock)
-      .filter(filterMock)
+      .filters(filterMock)
       .aggregator(aggregatorMock)
       .uploaders(uploaderMock)
       .start({});
@@ -123,7 +123,7 @@ describe('Pipe', () => {
       .adapters(adapterPair)
       .loaders(loaderMock)
       .processors(processorMock)
-      .filter(filterMock)
+      .filters(filterMock)
       .aggregator(aggregatorMock)
       .uploaders(uploaderMock)
       .start({});
@@ -145,7 +145,7 @@ describe('Pipe', () => {
       .adapters(adapterPair)
       .loaders(loaderMock)
       .processors(processorMock)
-      .filter(filterMock)
+      .filters(filterMock)
       .aggregator(aggregatorMock)
       .uploaders(uploaderMock)
       .start({});
@@ -174,7 +174,7 @@ describe('Pipe', () => {
           .destination(destinationAdapter)
           .loaders(loaderMock)
           .processors(processorMock)
-          .filter(filterMock)
+          .filters(filterMock)
           .aggregator(aggregatorMock)
           .uploaders(uploaderMock);
       };

--- a/src/pipe/pipe.ts
+++ b/src/pipe/pipe.ts
@@ -106,11 +106,11 @@ export class Pipe {
   }
 
   /**
-   * Define filter task
-   * @param {Filter} filter
+   * Define filter tasks
+   * @param {Filter[]} filters
    */
-  public filter(filter: Filter): Pipe {
-    this.filterList = [filter];
+  public filters(...filters: Filter[]): Pipe {
+    this.filterList = filters;
     return this;
   }
 

--- a/src/salesforce/configurer.ts
+++ b/src/salesforce/configurer.ts
@@ -24,7 +24,7 @@ export const configurer: Configurer = (pipe: Pipe) => {
       new DocumentLinkProcessor(),
       new NameConflictResolver(),
     )
-    .filter(new ModificationDateFilter())
+    .filters(new ModificationDateFilter())
     .aggregator(new DiffAggregator())
     .uploaders(new DiffUploader());
 };

--- a/src/servicenow/configurer.ts
+++ b/src/servicenow/configurer.ts
@@ -11,6 +11,7 @@ import { ServiceNowLoader } from './servicenow-loader.js';
 import { UrlTransformer } from '../processor/url-transformer/url-transformer.js';
 import { NameConflictResolver } from '../processor/name-conflict-resolver/name-conflict-resolver.js';
 import { ModificationDateFilter } from '../filter/modification-date-filter.js';
+import { DuplicateFilter } from '../filter/duplicate-filter.js';
 
 export const configurer: Configurer = (pipe: Pipe): void => {
   pipe
@@ -24,7 +25,7 @@ export const configurer: Configurer = (pipe: Pipe): void => {
       new DocumentLinkProcessor(),
       new NameConflictResolver(),
     )
-    .filter(new ModificationDateFilter())
+    .filters(new DuplicateFilter(), new ModificationDateFilter())
     .aggregator(new DiffAggregator())
     .uploaders(new DiffUploader());
 };

--- a/src/utils/pager.ts
+++ b/src/utils/pager.ts
@@ -24,7 +24,7 @@ export class Pager<T> {
         return;
       }
 
-      this.unprocessedItems = nextPage;
+      this.unprocessedItems.push(...nextPage);
 
       getLogger().debug(`Loaded ${nextPage.length} items`);
       for await (const item of this.processList(this.unprocessedItems)) {

--- a/src/zendesk/configurer.ts
+++ b/src/zendesk/configurer.ts
@@ -24,7 +24,7 @@ export const configurer: Configurer = (pipe: Pipe) => {
       new DocumentLinkProcessor(),
       new NameConflictResolver(),
     )
-    .filter(new ModificationDateFilter())
+    .filters(new ModificationDateFilter())
     .aggregator(new DiffAggregator())
     .uploaders(new DiffUploader());
 };


### PR DESCRIPTION
- Duplicate filter to prevent syncing multiple articles with the same external ID
- Updated pagination handling: next page results are now added to unprocessedItems collection

